### PR TITLE
Add workflow to deploy plugin

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,5 @@ jobs:
           BSR_USER: ${{ secrets.BSR_USER }}
           BSR_TOKEN: ${{ secrets.BSR_TOKEN }}
         run: |
-          buf --version
           echo ${BSR_TOKEN} | buf registry login --username ${BSR_USER} --token-stdin
           buf alpha plugin push ${{ github.event.inputs.plugin-directory }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,40 @@
+name: Deploy
+
+permissions: read-all
+
+on:
+  workflow_dispatch:
+    inputs:
+      plugin-directory:
+        description: "Plugin directory"
+        required: true
+
+jobs:
+  deploy-plugin:
+    runs-on: ubuntu-latest
+    name: Deploy plugin to BSR
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "1.19"
+      - name: Install buf cli
+        run: |
+          go install github.com/bufbuild/buf/cmd/buf@main
+      - name: Deploy plugin
+        env:
+          BUF_BETA_SUPPRESS_WARNINGS: 1
+          BSR_USER: ${{ secrets.BSR_USER }}
+          BSR_TOKEN: ${{ secrets.BSR_TOKEN }}
+        run: |
+          buf --version
+          echo ${BSR_TOKEN} | buf registry login --username ${BSR_USER} --token-stdin
+          buf alpha plugin push ${{ github.event.inputs.plugin-directory }}


### PR DESCRIPTION
This PR adds GitHub Action workflow to deploy a plugin to the BSR.

The `plugin-directory` is expected to be the versioned directory. E.g., `library/connect-go/v0.4.0`

Eventually we'll want to trigger this on merges to main, and optionally, only build/deploy changed directories. Alternative, we can deploy the kitchen sink and rely on BSR to resolve the plugin state.