### PR TITLE
update to build go plugins with 1.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,8 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: 1.19
+        check-latest: true
     - name: Cache
       uses: actions/cache@v3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version: 1.19.x
         check-latest: true
     - name: Cache
       uses: actions/cache@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -40,7 +40,8 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: 1.19.x
+        check-latest: true
     - name: Cache
       uses: actions/cache@v3
       with:

--- a/contrib/chrusty/jsonschema/v1.3.9/Dockerfile
+++ b/contrib/chrusty/jsonschema/v1.3.9/Dockerfile
@@ -1,9 +1,7 @@
 # syntax=docker/dockerfile:1.4
-FROM golang:1.18-bullseye AS build
-
+FROM golang:1.19-bullseye AS build
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
-
 WORKDIR /app
 RUN --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 \

--- a/library/connect-go/v0.1.1/Dockerfile
+++ b/library/connect-go/v0.1.1/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM golang:1.18-bullseye AS build
+FROM golang:1.19-bullseye AS build
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app

--- a/library/connect-go/v0.2.0/Dockerfile
+++ b/library/connect-go/v0.2.0/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM golang:1.18-bullseye AS build
+FROM golang:1.19-bullseye AS build
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app

--- a/library/connect-go/v0.3.0/Dockerfile
+++ b/library/connect-go/v0.3.0/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM golang:1.18-bullseye AS build
+FROM golang:1.19-bullseye AS build
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app

--- a/library/connect-go/v0.4.0/Dockerfile
+++ b/library/connect-go/v0.4.0/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM golang:1.18-bullseye AS build
+FROM golang:1.19-bullseye AS build
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app

--- a/library/go/v1.28.0/Dockerfile
+++ b/library/go/v1.28.0/Dockerfile
@@ -1,9 +1,7 @@
 # syntax=docker/dockerfile:1.4
-FROM golang:1.18-bullseye AS build
-
+FROM golang:1.19-bullseye AS build
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
-
 WORKDIR /app
 RUN --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 \

--- a/library/go/v1.28.1/Dockerfile
+++ b/library/go/v1.28.1/Dockerfile
@@ -1,9 +1,7 @@
 # syntax=docker/dockerfile:1.4
-FROM golang:1.18-bullseye AS build
-
+FROM golang:1.19-bullseye AS build
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
-
 WORKDIR /app
 RUN --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 \

--- a/library/grpc-go/v1.2.0/Dockerfile
+++ b/library/grpc-go/v1.2.0/Dockerfile
@@ -1,9 +1,7 @@
 # syntax=docker/dockerfile:1.4
-FROM golang:1.18-bullseye AS build
-
+FROM golang:1.19-bullseye AS build
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
-
 WORKDIR /app
 RUN --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 \


### PR DESCRIPTION
Go 1.19 introduces new formatting of doc comments. Upgrade plugins so
that they match the latest formatted code.