### PR TITLE
specify -trimpath when building connect-go

### DIFF
--- a/library/connect-go/v0.1.1/Dockerfile
+++ b/library/connect-go/v0.1.1/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 ENV GOBIN=/app
 RUN --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 \
-    go install -ldflags="-s -w" github.com/bufbuild/connect-go/cmd/protoc-gen-connect-go@${PLUGIN_VERSION}
+    go install -ldflags="-s -w" -trimpath github.com/bufbuild/connect-go/cmd/protoc-gen-connect-go@${PLUGIN_VERSION}
 
 FROM scratch
 WORKDIR /app

--- a/library/connect-go/v0.2.0/Dockerfile
+++ b/library/connect-go/v0.2.0/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 ENV GOBIN=/app
 RUN --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 \
-    go install -ldflags="-s -w" github.com/bufbuild/connect-go/cmd/protoc-gen-connect-go@${PLUGIN_VERSION}
+    go install -ldflags="-s -w" -trimpath github.com/bufbuild/connect-go/cmd/protoc-gen-connect-go@${PLUGIN_VERSION}
 
 FROM scratch
 WORKDIR /app

--- a/library/connect-go/v0.3.0/Dockerfile
+++ b/library/connect-go/v0.3.0/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 ENV GOBIN=/app
 RUN --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 \
-    go install -ldflags="-s -w" github.com/bufbuild/connect-go/cmd/protoc-gen-connect-go@${PLUGIN_VERSION}
+    go install -ldflags="-s -w" -trimpath github.com/bufbuild/connect-go/cmd/protoc-gen-connect-go@${PLUGIN_VERSION}
 
 FROM scratch
 WORKDIR /app

--- a/library/connect-go/v0.4.0/Dockerfile
+++ b/library/connect-go/v0.4.0/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 ENV GOBIN=/app
 RUN --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 \
-    go install -ldflags="-s -w" github.com/bufbuild/connect-go/cmd/protoc-gen-connect-go@${PLUGIN_VERSION}
+    go install -ldflags="-s -w" -trimpath github.com/bufbuild/connect-go/cmd/protoc-gen-connect-go@${PLUGIN_VERSION}
 
 FROM scratch
 WORKDIR /app


### PR DESCRIPTION
Update the connect-go plugins to specify -trimpath to hopefully avoid
small differences in published images.