### PR TITLE
build and publish to local registry for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-plugins-ci-${{ hashFiles('**/go.sum') }}
-        restore-keys: ${{ runner.os }}-plugins-ci-
+        restore-keys: ${{ runner.os }}-plugins-ci
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
     - name: Set up Docker Buildx

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,6 +12,11 @@ permissions: read-all
 jobs:
   pr:
     runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
     steps:
     - uses: actions/checkout@v3
       with:
@@ -47,23 +52,24 @@ jobs:
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-plugins-ci-${{ hashFiles('**/go.sum') }}
-        restore-keys: ${{ runner.os }}-plugins-ci-
+        restore-keys: ${{ runner.os }}-plugins-ci
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v2
       with:
-        driver: docker
+        driver-opts: network=host
     - name: Build
       env:
         ALL_MODIFIED_FILES: ${{ steps.changed-files.outputs.all_modified_files }}
         ANY_MODIFIED: ${{ steps.changed-files.outputs.any_modified }}
       shell: bash
-      run: make
+      run: make DOCKER_ORG="localhost:5000/bufbuild" DOCKER_BUILD_EXTRA_ARGS="--build-arg BUILDKIT_INLINE_CACHE=1 --push"
     - name: Test
       env:
         ALL_MODIFIED_FILES: ${{ steps.changed-files.outputs.all_modified_files }}
         ANY_MODIFIED: ${{ steps.changed-files.outputs.any_modified }}
+        DOCKER_ORG: "localhost:5000/bufbuild"
       shell: bash
       run: make test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -70,6 +70,5 @@ jobs:
       env:
         ALL_MODIFIED_FILES: ${{ steps.changed-files.outputs.all_modified_files }}
         ANY_MODIFIED: ${{ steps.changed-files.outputs.any_modified }}
-        DOCKER_ORG: "localhost:5000/bufbuild"
       shell: bash
-      run: make test
+      run: make test DOCKER_ORG="localhost:5000/bufbuild"

--- a/Makefile
+++ b/Makefile
@@ -29,17 +29,17 @@ test:
 	go test $(GO_TEST_FLAGS) ./...
 
 .build/base/library/%/base-build/image: library/%/base-build/Dockerfile
-	$(DOCKER) $(DOCKER_BUILD_ARGS) -t $(DOCKER_ORG)/plugins-$*-base-build $(<D)
+	$(DOCKER) $(DOCKER_BUILD_ARGS) $(DOCKER_BUILD_EXTRA_ARGS) -t $(DOCKER_ORG)/plugins-$*-base-build $(<D)
 	@mkdir -p $(dir $@) && touch $@
 
 .build/base/library/grpc/v%/base/image: library/grpc/v%/base/Dockerfile
 	VERSION=v$(shell basename $*); \
-	$(DOCKER) $(DOCKER_BUILD_ARGS) --build-arg VERSION=$${VERSION} -t $(DOCKER_ORG)/plugins-grpc-base:$${VERSION} $(<D)
+	$(DOCKER) $(DOCKER_BUILD_ARGS) $(DOCKER_BUILD_EXTRA_ARGS) --build-arg VERSION=$${VERSION} -t $(DOCKER_ORG)/plugins-grpc-base:$${VERSION} $(<D)
 	@mkdir -p $(dir $@) && touch $@
 
 .build/base/library/protoc/v%/base/image: library/protoc/v%/base/Dockerfile
 	VERSION=v$(shell basename $*); \
-	$(DOCKER) $(DOCKER_BUILD_ARGS) --build-arg VERSION=$${VERSION} -t $(DOCKER_ORG)/plugins-protoc-base:$${VERSION} $(<D)
+	$(DOCKER) $(DOCKER_BUILD_ARGS) $(DOCKER_BUILD_EXTRA_ARGS) --build-arg VERSION=$${VERSION} -t $(DOCKER_ORG)/plugins-protoc-base:$${VERSION} $(<D)
 	@mkdir -p $(dir $@) && touch $@
 
 .build/plugin/%/image: %/Dockerfile %/buf.plugin.yaml $(BASE_IMAGES)
@@ -48,7 +48,7 @@ test:
 	PLUGIN_NAME=`echo "$${PLUGIN_FULL_NAME}" | cut -d '/' -f 3-`; \
 	PLUGIN_VERSION=$(shell yq '.plugin_version' $*/buf.plugin.yaml); \
 	test -n "$${PLUGIN_NAME}" -a -n "$${PLUGIN_VERSION}" && \
-	$(DOCKER) $(DOCKER_BUILD_ARGS) --build-arg PLUGIN_VERSION=$${PLUGIN_VERSION} -t $(DOCKER_ORG)/plugins-$${PLUGIN_OWNER}-$${PLUGIN_NAME}:$${PLUGIN_VERSION} $(<D)
+	$(DOCKER) $(DOCKER_BUILD_ARGS) $(DOCKER_BUILD_EXTRA_ARGS) --build-arg PLUGIN_VERSION=$${PLUGIN_VERSION} -t $(DOCKER_ORG)/plugins-$${PLUGIN_OWNER}-$${PLUGIN_NAME}:$${PLUGIN_VERSION} $(<D)
 	@mkdir -p $(dir $@) && touch $@
 
 .PHONY: push

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 .DEFAULT_GOAL := all
 
 DOCKER ?= docker
-DOCKER_BUILD_ARGS ?= buildx build
+DOCKER_ORG ?= bufbuild
+DOCKER_BUILD_ARGS ?= buildx build --build-arg DOCKER_ORG="$(DOCKER_ORG)"
+DOCKER_BUILD_EXTRA_ARGS ?=
 
 GO_TEST_FLAGS ?= -race -count=1
 
@@ -27,17 +29,17 @@ test:
 	go test $(GO_TEST_FLAGS) ./...
 
 .build/base/library/%/base-build/image: library/%/base-build/Dockerfile
-	$(DOCKER) $(DOCKER_BUILD_ARGS) -t bufbuild/plugins-$*-base-build $(<D)
+	$(DOCKER) $(DOCKER_BUILD_ARGS) -t $(DOCKER_ORG)/plugins-$*-base-build $(<D)
 	@mkdir -p $(dir $@) && touch $@
 
 .build/base/library/grpc/v%/base/image: library/grpc/v%/base/Dockerfile
-	GRPC_VERSION=v$(shell basename $*); \
-	$(DOCKER) $(DOCKER_BUILD_ARGS) --build-arg GRPC_VERSION=$${GRPC_VERSION} -t bufbuild/plugins-grpc-base:$${GRPC_VERSION} $(<D)
+	VERSION=v$(shell basename $*); \
+	$(DOCKER) $(DOCKER_BUILD_ARGS) --build-arg VERSION=$${VERSION} -t $(DOCKER_ORG)/plugins-grpc-base:$${VERSION} $(<D)
 	@mkdir -p $(dir $@) && touch $@
 
 .build/base/library/protoc/v%/base/image: library/protoc/v%/base/Dockerfile
-	PROTOC_VERSION=v$(shell basename $*); \
-	$(DOCKER) $(DOCKER_BUILD_ARGS) --build-arg PROTOC_VERSION=$${PROTOC_VERSION} -t bufbuild/plugins-protoc-base:$${PROTOC_VERSION} $(<D)
+	VERSION=v$(shell basename $*); \
+	$(DOCKER) $(DOCKER_BUILD_ARGS) --build-arg VERSION=$${VERSION} -t $(DOCKER_ORG)/plugins-protoc-base:$${VERSION} $(<D)
 	@mkdir -p $(dir $@) && touch $@
 
 .build/plugin/%/image: %/Dockerfile %/buf.plugin.yaml $(BASE_IMAGES)
@@ -46,7 +48,7 @@ test:
 	PLUGIN_NAME=`echo "$${PLUGIN_FULL_NAME}" | cut -d '/' -f 3-`; \
 	PLUGIN_VERSION=$(shell yq '.plugin_version' $*/buf.plugin.yaml); \
 	test -n "$${PLUGIN_NAME}" -a -n "$${PLUGIN_VERSION}" && \
-	$(DOCKER) $(DOCKER_BUILD_ARGS) --build-arg PLUGIN_VERSION=$${PLUGIN_VERSION} -t bufbuild/plugins-$${PLUGIN_OWNER}-$${PLUGIN_NAME}:$${PLUGIN_VERSION} $(<D)
+	$(DOCKER) $(DOCKER_BUILD_ARGS) --build-arg PLUGIN_VERSION=$${PLUGIN_VERSION} -t $(DOCKER_ORG)/plugins-$${PLUGIN_OWNER}-$${PLUGIN_NAME}:$${PLUGIN_VERSION} $(<D)
 	@mkdir -p $(dir $@) && touch $@
 
 .PHONY: push

--- a/library/grpc/base-build/.dockerignore
+++ b/library/grpc/base-build/.dockerignore
@@ -1,0 +1,2 @@
+*
+!Dockerfile

--- a/library/grpc/v1.48.0/base/.dockerignore
+++ b/library/grpc/v1.48.0/base/.dockerignore
@@ -1,0 +1,2 @@
+*
+!Dockerfile

--- a/library/grpc/v1.48.0/base/Dockerfile
+++ b/library/grpc/v1.48.0/base/Dockerfile
@@ -1,10 +1,12 @@
 # syntax=docker/dockerfile:1.4
-FROM bufbuild/plugins-grpc-base-build:latest
+ARG DOCKER_ORG=bufbuild
+ARG BASE_BUILD_VERSION=latest
+FROM ${DOCKER_ORG}/plugins-grpc-base-build:${BASE_BUILD_VERSION}
 
-ARG GRPC_VERSION
-RUN test -n "${GRPC_VERSION}"
+ARG VERSION
+RUN test -n "${VERSION}"
 
-RUN git clone --depth 1 --branch ${GRPC_VERSION} --recursive https://github.com/grpc/grpc
+RUN git clone --depth 1 --branch ${VERSION} --recursive https://github.com/grpc/grpc
 WORKDIR /build/grpc
 RUN cmake . \
  && cmake --build . --target plugins

--- a/library/grpc/v1.48.0/cpp/Dockerfile
+++ b/library/grpc/v1.48.0/cpp/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-grpc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-grpc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/grpc/v1.48.0/csharp/Dockerfile
+++ b/library/grpc/v1.48.0/csharp/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-grpc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-grpc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/grpc/v1.48.0/objc/Dockerfile
+++ b/library/grpc/v1.48.0/objc/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-grpc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-grpc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/grpc/v1.48.0/php/Dockerfile
+++ b/library/grpc/v1.48.0/php/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-grpc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-grpc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/grpc/v1.48.0/python/Dockerfile
+++ b/library/grpc/v1.48.0/python/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-grpc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-grpc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/grpc/v1.48.0/ruby/Dockerfile
+++ b/library/grpc/v1.48.0/ruby/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-grpc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-grpc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/protoc/base-build/.dockerignore
+++ b/library/protoc/base-build/.dockerignore
@@ -1,0 +1,3 @@
+*
+!Dockerfile
+!plugins

--- a/library/protoc/v21.3/base/.dockerignore
+++ b/library/protoc/v21.3/base/.dockerignore
@@ -1,0 +1,2 @@
+*
+!Dockerfile

--- a/library/protoc/v21.3/base/Dockerfile
+++ b/library/protoc/v21.3/base/Dockerfile
@@ -1,10 +1,12 @@
 # syntax=docker/dockerfile:1.4
-FROM bufbuild/plugins-protoc-base-build:latest
+ARG DOCKER_ORG=bufbuild
+ARG BASE_BUILD_VERSION=latest
+FROM ${DOCKER_ORG}/plugins-protoc-base-build:${BASE_BUILD_VERSION}
 
-ARG PROTOC_VERSION
-RUN test -n "${PROTOC_VERSION}"
+ARG VERSION
+RUN test -n "${VERSION}"
 
-RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch ${PROTOC_VERSION} --recursive
+RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch ${VERSION} --recursive
 WORKDIR /build/protobuf/
 RUN ["ln", "-s", "/build/plugins", "."]
 RUN ["/bin/bash", "-c", "bazel build $(bazel query 'kind(cc_binary, //plugins/...)')"]

--- a/library/protoc/v21.3/cpp/Dockerfile
+++ b/library/protoc/v21.3/cpp/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-protoc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/protoc/v21.3/csharp/Dockerfile
+++ b/library/protoc/v21.3/csharp/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-protoc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/protoc/v21.3/java/Dockerfile
+++ b/library/protoc/v21.3/java/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-protoc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/protoc/v21.3/kotlin/Dockerfile
+++ b/library/protoc/v21.3/kotlin/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-protoc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/protoc/v21.3/objc/Dockerfile
+++ b/library/protoc/v21.3/objc/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-protoc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/protoc/v21.3/php/Dockerfile
+++ b/library/protoc/v21.3/php/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-protoc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/protoc/v21.3/python/Dockerfile
+++ b/library/protoc/v21.3/python/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-protoc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/protoc/v21.3/ruby/Dockerfile
+++ b/library/protoc/v21.3/ruby/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-protoc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/protoc/v21.4/base/.dockerignore
+++ b/library/protoc/v21.4/base/.dockerignore
@@ -1,0 +1,2 @@
+*
+!Dockerfile

--- a/library/protoc/v21.4/base/Dockerfile
+++ b/library/protoc/v21.4/base/Dockerfile
@@ -1,10 +1,12 @@
 # syntax=docker/dockerfile:1.4
-FROM bufbuild/plugins-protoc-base-build:latest
+ARG DOCKER_ORG=bufbuild
+ARG BASE_BUILD_VERSION=latest
+FROM ${DOCKER_ORG}/plugins-protoc-base-build:${BASE_BUILD_VERSION}
 
-ARG PROTOC_VERSION
-RUN test -n "${PROTOC_VERSION}"
+ARG VERSION
+RUN test -n "${VERSION}"
 
-RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch ${PROTOC_VERSION} --recursive
+RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch ${VERSION} --recursive
 WORKDIR /build/protobuf/
 RUN ["ln", "-s", "/build/plugins", "."]
 RUN ["/bin/bash", "-c", "bazel build $(bazel query 'kind(cc_binary, //plugins/...)')"]

--- a/library/protoc/v21.4/cpp/Dockerfile
+++ b/library/protoc/v21.4/cpp/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-protoc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/protoc/v21.4/csharp/Dockerfile
+++ b/library/protoc/v21.4/csharp/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-protoc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/protoc/v21.4/java/Dockerfile
+++ b/library/protoc/v21.4/java/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-protoc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/protoc/v21.4/kotlin/Dockerfile
+++ b/library/protoc/v21.4/kotlin/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-protoc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/protoc/v21.4/objc/Dockerfile
+++ b/library/protoc/v21.4/objc/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-protoc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/protoc/v21.4/php/Dockerfile
+++ b/library/protoc/v21.4/php/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-protoc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/protoc/v21.4/python/Dockerfile
+++ b/library/protoc/v21.4/python/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-protoc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/protoc/v21.4/ruby/Dockerfile
+++ b/library/protoc/v21.4/ruby/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-protoc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/protoc/v21.5/base/.dockerignore
+++ b/library/protoc/v21.5/base/.dockerignore
@@ -1,0 +1,2 @@
+*
+!Dockerfile

--- a/library/protoc/v21.5/base/Dockerfile
+++ b/library/protoc/v21.5/base/Dockerfile
@@ -1,10 +1,12 @@
 # syntax=docker/dockerfile:1.4
-FROM bufbuild/plugins-protoc-base-build:latest
+ARG DOCKER_ORG=bufbuild
+ARG BASE_BUILD_VERSION=latest
+FROM ${DOCKER_ORG}/plugins-protoc-base-build:${BASE_BUILD_VERSION}
 
-ARG PROTOC_VERSION
-RUN test -n "${PROTOC_VERSION}"
+ARG VERSION
+RUN test -n "${VERSION}"
 
-RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch ${PROTOC_VERSION} --recursive
+RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch ${VERSION} --recursive
 WORKDIR /build/protobuf/
 RUN ["ln", "-s", "/build/plugins", "."]
 RUN ["/bin/bash", "-c", "bazel build $(bazel query 'kind(cc_binary, //plugins/...)')"]

--- a/library/protoc/v21.5/cpp/Dockerfile
+++ b/library/protoc/v21.5/cpp/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-protoc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/protoc/v21.5/csharp/Dockerfile
+++ b/library/protoc/v21.5/csharp/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-protoc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/protoc/v21.5/java/Dockerfile
+++ b/library/protoc/v21.5/java/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-protoc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/protoc/v21.5/kotlin/Dockerfile
+++ b/library/protoc/v21.5/kotlin/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-protoc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/protoc/v21.5/objc/Dockerfile
+++ b/library/protoc/v21.5/objc/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-protoc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/protoc/v21.5/php/Dockerfile
+++ b/library/protoc/v21.5/php/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-protoc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/protoc/v21.5/python/Dockerfile
+++ b/library/protoc/v21.5/python/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-protoc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/protoc/v21.5/ruby/Dockerfile
+++ b/library/protoc/v21.5/ruby/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-protoc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/protoc/v3.20.1/base/.dockerignore
+++ b/library/protoc/v3.20.1/base/.dockerignore
@@ -1,0 +1,3 @@
+*
+!Dockerfile
+!plugins

--- a/library/protoc/v3.20.1/base/Dockerfile
+++ b/library/protoc/v3.20.1/base/Dockerfile
@@ -1,10 +1,12 @@
 # syntax=docker/dockerfile:1.4
-FROM bufbuild/plugins-protoc-base-build:latest
+ARG DOCKER_ORG=bufbuild
+ARG BASE_BUILD_VERSION=latest
+FROM ${DOCKER_ORG}/plugins-protoc-base-build:${BASE_BUILD_VERSION}
 
-ARG PROTOC_VERSION
-RUN test -n "${PROTOC_VERSION}"
+ARG VERSION
+RUN test -n "${VERSION}"
 
-RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch ${PROTOC_VERSION} --recursive
+RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch ${VERSION} --recursive
 WORKDIR /build/protobuf/
 COPY plugins/* /build/plugins/
 RUN ["ln", "-s", "/build/plugins", "."]

--- a/library/protoc/v3.20.1/cpp/Dockerfile
+++ b/library/protoc/v3.20.1/cpp/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-protoc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/protoc/v3.20.1/csharp/Dockerfile
+++ b/library/protoc/v3.20.1/csharp/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-protoc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/protoc/v3.20.1/java/Dockerfile
+++ b/library/protoc/v3.20.1/java/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-protoc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/protoc/v3.20.1/js/Dockerfile
+++ b/library/protoc/v3.20.1/js/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-protoc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/protoc/v3.20.1/kotlin/Dockerfile
+++ b/library/protoc/v3.20.1/kotlin/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-protoc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/protoc/v3.20.1/objc/Dockerfile
+++ b/library/protoc/v3.20.1/objc/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-protoc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/protoc/v3.20.1/php/Dockerfile
+++ b/library/protoc/v3.20.1/php/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-protoc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/protoc/v3.20.1/python/Dockerfile
+++ b/library/protoc/v3.20.1/python/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-protoc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/library/protoc/v3.20.1/ruby/Dockerfile
+++ b/library/protoc/v3.20.1/ruby/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 ARG PLUGIN_VERSION
-FROM bufbuild/plugins-protoc-base:${PLUGIN_VERSION} as build
+ARG DOCKER_ORG=bufbuild
+FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-slim
 WORKDIR /app

--- a/tests/plugins_test.go
+++ b/tests/plugins_test.go
@@ -156,8 +156,12 @@ func createProtocGenPlugin(t *testing.T, basedir string, plugin *plugin.Plugin) 
 	if len(fields) != 3 {
 		return fmt.Errorf("invalid plugin name: %v", plugin.Name)
 	}
+	dockerOrg := os.Getenv("DOCKER_ORG")
+	if len(dockerOrg) == 0 {
+		dockerOrg = "bufbuild"
+	}
 	return protocGenPluginTemplate.Execute(protocGenPlugin, map[string]any{
-		"ImageName": fmt.Sprintf("bufbuild/plugins-%s-%s", fields[1], fields[2]),
+		"ImageName": fmt.Sprintf("%s/plugins-%s-%s", dockerOrg, fields[1], fields[2]),
 		"Version":   plugin.Version,
 	})
 }


### PR DESCRIPTION
Update the PR workflow to start a local registry and build/publish
images to the local registry instead of the Docker host. This is the
start of support for building/caching to GHCR for optimizing main branch
builds.