### PR TITLE
use specific base images

### DIFF
--- a/contrib/chrusty/jsonschema/v1.3.9/Dockerfile
+++ b/contrib/chrusty/jsonschema/v1.3.9/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM golang:1.19-bullseye AS build
+FROM golang:1.19.0-bullseye AS build
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app

--- a/library/connect-go/v0.1.1/Dockerfile
+++ b/library/connect-go/v0.1.1/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM golang:1.19-bullseye AS build
+FROM golang:1.19.0-bullseye AS build
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app

--- a/library/connect-go/v0.2.0/Dockerfile
+++ b/library/connect-go/v0.2.0/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM golang:1.19-bullseye AS build
+FROM golang:1.19.0-bullseye AS build
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app

--- a/library/connect-go/v0.3.0/Dockerfile
+++ b/library/connect-go/v0.3.0/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM golang:1.19-bullseye AS build
+FROM golang:1.19.0-bullseye AS build
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app

--- a/library/connect-go/v0.4.0/Dockerfile
+++ b/library/connect-go/v0.4.0/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM golang:1.19-bullseye AS build
+FROM golang:1.19.0-bullseye AS build
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app

--- a/library/connect-web/v0.0.10/Dockerfile
+++ b/library/connect-web/v0.0.10/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM node:lts-bullseye-slim
+FROM node:16.17.0-bullseye-slim
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app

--- a/library/connect-web/v0.1.0/Dockerfile
+++ b/library/connect-web/v0.1.0/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM node:lts-bullseye-slim
+FROM node:16.17.0-bullseye-slim
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app

--- a/library/dart/v20.0.1/Dockerfile
+++ b/library/dart/v20.0.1/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM dart:stable as build
+FROM dart:2.17.6-sdk as build
 
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"

--- a/library/go/v1.28.0/Dockerfile
+++ b/library/go/v1.28.0/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM golang:1.19-bullseye AS build
+FROM golang:1.19.0-bullseye AS build
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app

--- a/library/go/v1.28.1/Dockerfile
+++ b/library/go/v1.28.1/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM golang:1.19-bullseye AS build
+FROM golang:1.19.0-bullseye AS build
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app

--- a/library/grpc-go/v1.2.0/Dockerfile
+++ b/library/grpc-go/v1.2.0/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM golang:1.19-bullseye AS build
+FROM golang:1.19.0-bullseye AS build
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app

--- a/library/grpc-java/v1.48.1/Dockerfile
+++ b/library/grpc-java/v1.48.1/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-slim AS build
+FROM debian:bullseye-20220822-slim AS build
 
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
@@ -18,7 +18,7 @@ RUN arch=${TARGETARCH}; \
     echo "${arch}"; \
     curl -fsSL -o protoc-gen-grpc-java https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/${PLUGIN_VERSION#v}/protoc-gen-grpc-java-${PLUGIN_VERSION#v}-linux-${arch}.exe
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 --chown=root:root /build/protoc-gen-grpc-java .
 USER nobody

--- a/library/grpc-kotlin/v1.3.0/Dockerfile
+++ b/library/grpc-kotlin/v1.3.0/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-slim AS build
+FROM debian:bullseye-20220822-slim AS build
 
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
@@ -11,7 +11,7 @@ RUN apt-get update \
  && apt-get install -y curl
 RUN curl -fsSL -o protoc-gen-grpc-kotlin.jar https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-kotlin/${PLUGIN_VERSION#v}/protoc-gen-grpc-kotlin-${PLUGIN_VERSION#v}-jdk8.jar
 
-FROM eclipse-temurin:17-jre-jammy
+FROM eclipse-temurin:17.0.4_8-jre-jammy
 WORKDIR /app
 COPY --from=build --chmod=0644 --chown=root:root /build/protoc-gen-grpc-kotlin.jar .
 COPY --chmod=0755 --chown=root:root <<'EOF' /entrypoint.sh

--- a/library/grpc-node/v1.11.2/Dockerfile
+++ b/library/grpc-node/v1.11.2/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM node:lts-bullseye AS build
+FROM node:16.17.0-bullseye AS build
 
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
@@ -24,7 +24,7 @@ else
 fi
 EOF
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 --chown=root:root /build/grpc_node_plugin .
 USER nobody

--- a/library/grpc-swift/v1.9.0/Dockerfile
+++ b/library/grpc-swift/v1.9.0/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM swift:5.6-focal AS build
+FROM swift:5.6.2-focal AS build
 
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
@@ -10,7 +10,7 @@ RUN git clone --depth 1 --branch ${PLUGIN_VERSION#v} https://github.com/grpc/grp
 WORKDIR /app/grpc-swift
 RUN swift build -c release --static-swift-stdlib --product protoc-gen-grpc-swift
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build /app/grpc-swift/.build/release/protoc-gen-grpc-swift .
 USER nobody

--- a/library/grpc-web/v1.3.1/Dockerfile
+++ b/library/grpc-web/v1.3.1/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye AS build
+FROM debian:bullseye-20220822 AS build
 
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
@@ -26,7 +26,7 @@ else
 fi
 EOF
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 --chown=root:root /build/protoc-gen-grpc-web .
 USER nobody

--- a/library/grpc/base-build/Dockerfile
+++ b/library/grpc/base-build/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye
+FROM debian:bullseye-20220822
 
 RUN apt-get update \
  && apt-get install -y git cmake build-essential

--- a/library/grpc/v1.48.0/cpp/Dockerfile
+++ b/library/grpc/v1.48.0/cpp/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-grpc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/grpc/grpc_cpp_plugin .
 USER nobody

--- a/library/grpc/v1.48.0/csharp/Dockerfile
+++ b/library/grpc/v1.48.0/csharp/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-grpc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/grpc/grpc_csharp_plugin .
 USER nobody

--- a/library/grpc/v1.48.0/objc/Dockerfile
+++ b/library/grpc/v1.48.0/objc/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-grpc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/grpc/grpc_objective_c_plugin .
 USER nobody

--- a/library/grpc/v1.48.0/php/Dockerfile
+++ b/library/grpc/v1.48.0/php/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-grpc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/grpc/grpc_php_plugin .
 USER nobody

--- a/library/grpc/v1.48.0/python/Dockerfile
+++ b/library/grpc/v1.48.0/python/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-grpc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/grpc/grpc_python_plugin .
 USER nobody

--- a/library/grpc/v1.48.0/ruby/Dockerfile
+++ b/library/grpc/v1.48.0/ruby/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-grpc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/grpc/grpc_ruby_plugin .
 USER nobody

--- a/library/protobuf-es/v0.0.10/Dockerfile
+++ b/library/protobuf-es/v0.0.10/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM node:lts-bullseye-slim
+FROM node:16.17.0-bullseye-slim
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app

--- a/library/protobuf-es/v0.0.9/Dockerfile
+++ b/library/protobuf-es/v0.0.9/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM node:lts-bullseye-slim
+FROM node:16.17.0-bullseye-slim
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app

--- a/library/protoc/base-build/Dockerfile
+++ b/library/protoc/base-build/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye
+FROM debian:bullseye-20220822
 
 ARG TARGETARCH
 ARG BAZEL_VERSION="4.2.1"

--- a/library/protoc/v21.3/cpp/Dockerfile
+++ b/library/protoc/v21.3/cpp/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-cpp .
 USER nobody

--- a/library/protoc/v21.3/csharp/Dockerfile
+++ b/library/protoc/v21.3/csharp/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-csharp .
 USER nobody

--- a/library/protoc/v21.3/java/Dockerfile
+++ b/library/protoc/v21.3/java/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-java .
 USER nobody

--- a/library/protoc/v21.3/kotlin/Dockerfile
+++ b/library/protoc/v21.3/kotlin/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-kotlin .
 USER nobody

--- a/library/protoc/v21.3/objc/Dockerfile
+++ b/library/protoc/v21.3/objc/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-objectivec .
 USER nobody

--- a/library/protoc/v21.3/php/Dockerfile
+++ b/library/protoc/v21.3/php/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-php .
 USER nobody

--- a/library/protoc/v21.3/python/Dockerfile
+++ b/library/protoc/v21.3/python/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-python .
 USER nobody

--- a/library/protoc/v21.3/ruby/Dockerfile
+++ b/library/protoc/v21.3/ruby/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-ruby .
 USER nobody

--- a/library/protoc/v21.4/cpp/Dockerfile
+++ b/library/protoc/v21.4/cpp/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-cpp .
 USER nobody

--- a/library/protoc/v21.4/csharp/Dockerfile
+++ b/library/protoc/v21.4/csharp/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-csharp .
 USER nobody

--- a/library/protoc/v21.4/java/Dockerfile
+++ b/library/protoc/v21.4/java/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-java .
 USER nobody

--- a/library/protoc/v21.4/kotlin/Dockerfile
+++ b/library/protoc/v21.4/kotlin/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-kotlin .
 USER nobody

--- a/library/protoc/v21.4/objc/Dockerfile
+++ b/library/protoc/v21.4/objc/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-objectivec .
 USER nobody

--- a/library/protoc/v21.4/php/Dockerfile
+++ b/library/protoc/v21.4/php/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-php .
 USER nobody

--- a/library/protoc/v21.4/python/Dockerfile
+++ b/library/protoc/v21.4/python/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-python .
 USER nobody

--- a/library/protoc/v21.4/ruby/Dockerfile
+++ b/library/protoc/v21.4/ruby/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-ruby .
 USER nobody

--- a/library/protoc/v21.5/cpp/Dockerfile
+++ b/library/protoc/v21.5/cpp/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-cpp .
 USER nobody

--- a/library/protoc/v21.5/csharp/Dockerfile
+++ b/library/protoc/v21.5/csharp/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-csharp .
 USER nobody

--- a/library/protoc/v21.5/java/Dockerfile
+++ b/library/protoc/v21.5/java/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-java .
 USER nobody

--- a/library/protoc/v21.5/kotlin/Dockerfile
+++ b/library/protoc/v21.5/kotlin/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-kotlin .
 USER nobody

--- a/library/protoc/v21.5/objc/Dockerfile
+++ b/library/protoc/v21.5/objc/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-objectivec .
 USER nobody

--- a/library/protoc/v21.5/php/Dockerfile
+++ b/library/protoc/v21.5/php/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-php .
 USER nobody

--- a/library/protoc/v21.5/python/Dockerfile
+++ b/library/protoc/v21.5/python/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-python .
 USER nobody

--- a/library/protoc/v21.5/ruby/Dockerfile
+++ b/library/protoc/v21.5/ruby/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-ruby .
 USER nobody

--- a/library/protoc/v3.20.1/cpp/Dockerfile
+++ b/library/protoc/v3.20.1/cpp/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-cpp .
 USER nobody

--- a/library/protoc/v3.20.1/csharp/Dockerfile
+++ b/library/protoc/v3.20.1/csharp/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-csharp .
 USER nobody

--- a/library/protoc/v3.20.1/java/Dockerfile
+++ b/library/protoc/v3.20.1/java/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-java .
 USER nobody

--- a/library/protoc/v3.20.1/js/Dockerfile
+++ b/library/protoc/v3.20.1/js/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-js .
 USER nobody

--- a/library/protoc/v3.20.1/kotlin/Dockerfile
+++ b/library/protoc/v3.20.1/kotlin/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-kotlin .
 USER nobody

--- a/library/protoc/v3.20.1/objc/Dockerfile
+++ b/library/protoc/v3.20.1/objc/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-objectivec .
 USER nobody

--- a/library/protoc/v3.20.1/php/Dockerfile
+++ b/library/protoc/v3.20.1/php/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-php .
 USER nobody

--- a/library/protoc/v3.20.1/python/Dockerfile
+++ b/library/protoc/v3.20.1/python/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-python .
 USER nobody

--- a/library/protoc/v3.20.1/ruby/Dockerfile
+++ b/library/protoc/v3.20.1/ruby/Dockerfile
@@ -3,7 +3,7 @@ ARG PLUGIN_VERSION
 ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-ruby .
 USER nobody

--- a/library/swift/v1.19.0/Dockerfile
+++ b/library/swift/v1.19.0/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM swift:5.6-focal AS build
+FROM swift:5.6.2-focal AS build
 
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
@@ -10,7 +10,7 @@ RUN ["/bin/bash", "-c", "git clone --depth 1 --branch ${PLUGIN_VERSION#v} https:
 WORKDIR /app/swift-protobuf
 RUN swift build -c release --static-swift-stdlib
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build /app/swift-protobuf/.build/release/protoc-gen-swift .
 USER nobody

--- a/library/swift/v1.19.1/Dockerfile
+++ b/library/swift/v1.19.1/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM swift:5.6-focal AS build
+FROM swift:5.6.2-focal AS build
 
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
@@ -10,7 +10,7 @@ RUN ["/bin/bash", "-c", "git clone --depth 1 --branch ${PLUGIN_VERSION#v} https:
 WORKDIR /app/swift-protobuf
 RUN swift build -c release --static-swift-stdlib
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220822-slim
 WORKDIR /app
 COPY --from=build /app/swift-protobuf/.build/release/protoc-gen-swift .
 USER nobody


### PR DESCRIPTION
To prevent unnecessary building when base images change (and improve
build reproducibility), target the most specific version of base images.