### PR TITLE
add dependabot config for unique docker bases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,38 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  # go plugin
   - package-ecosystem: "docker"
-    directory: "/"
+    directory: "/library/connect-go/v0.4.0"
+    schedule:
+      interval: "weekly"
+  # node slim plugin
+  - package-ecosystem: "docker"
+    directory: "/library/connect-web/v0.1.0"
+    schedule:
+      interval: "weekly"
+  # node full plugin
+  - package-ecosystem: "docker"
+    directory: "/library/grpc-node/v1.11.2"
+    schedule:
+      interval: "weekly"
+  # dart plugin
+  - package-ecosystem: "docker"
+    directory: "/library/dart/v20.0.1"
+    schedule:
+      interval: "weekly"
+  # java plugin
+  - package-ecosystem: "docker"
+    directory: "/library/grpc-kotlin/v1.3.0"
+    schedule:
+      interval: "weekly"
+  # swift plugin
+  - package-ecosystem: "docker"
+    directory: "/library/swift/v1.19.1"
+    schedule:
+      interval: "weekly"
+  # debian bullseye
+  - package-ecosystem: "docker"
+    directory: "/library/protoc/base-build"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Update the dependabot config to point at Docker image updates for each
unique base image (i.e. go, node, debian, swift, dart, java). This
should alert us when new base images are available but we'll still want
to bump versions in unison across all the plugins.