### PR TITLE
Exclude prereleases by default

### DIFF
--- a/cmd/fetcher/main.go
+++ b/cmd/fetcher/main.go
@@ -55,6 +55,10 @@ func run(ctx context.Context, root string, depth int) error {
 		}
 		newVersion, err := client.Fetch(ctx, config)
 		if err != nil {
+			if errors.Is(err, fetchclient.ErrSkipPrerelease) {
+				log.Println(err)
+				continue
+			}
 			return err
 		}
 		// example: library/grpc

--- a/cmd/fetcher/main.go
+++ b/cmd/fetcher/main.go
@@ -55,11 +55,12 @@ func run(ctx context.Context, root string, depth int) error {
 		}
 		newVersion, err := client.Fetch(ctx, config)
 		if err != nil {
-			if errors.Is(err, fetchclient.ErrSkipPrerelease) {
-				log.Println(err)
-				continue
-			}
 			return err
+		}
+		// For now we ignore prerelease versions. But this may change in the future.
+		if semver.Prerelease(newVersion) != "" && !config.IncludePrerelease {
+			log.Printf("%s: skipping prerelease version: %s", config.Source.Name(), newVersion)
+			continue
 		}
 		// example: library/grpc
 		pluginDir := filepath.Dir(config.Filename)

--- a/internal/fetchclient/fetchclient.go
+++ b/internal/fetchclient/fetchclient.go
@@ -25,8 +25,6 @@ const (
 	mavenSearchURL = "https://search.maven.org/solrsearch/select"
 )
 
-var ErrSkipPrerelease = errors.New("skipping prerelease version")
-
 // Client is a client used to fetch latest package version.
 type Client struct {
 	httpClient *http.Client
@@ -55,10 +53,6 @@ func (c *Client) Fetch(ctx context.Context, config *source.Config) (string, erro
 	validSemver, ok := ensureSemverPrefix(version)
 	if !ok {
 		return "", fmt.Errorf("%s: invalid semver: %s", config.Source.Name(), version)
-	}
-	// For now we ignore prerelease versions. But this may change in the future.
-	if semver.Prerelease(validSemver) != "" && !config.IncludePrerelease {
-		return "", fmt.Errorf("%s: %w: %s", config.Source.Name(), ErrSkipPrerelease, validSemver)
 	}
 	return validSemver, nil
 }

--- a/internal/source/config.go
+++ b/internal/source/config.go
@@ -21,6 +21,9 @@ func NewConfig(reader io.Reader) (*Config, error) {
 type Config struct {
 	Filename string       `yaml:"-"`
 	Source   SourceConfig `yaml:"source"`
+	// IncludePrerelease includes semver prereleases when fecthing versions
+	// from upstream.
+	IncludePrerelease bool `yaml:"include_prerelease"`
 }
 
 // SourceConfig is the configuration for the fetch source.


### PR DESCRIPTION
This PR adds a new source.yaml option to allow including prerelease versions.

If the latest fetched version is a prerelease, and `include_prerelease: true` is not set then we log it and ignore.