### PR TITLE
run buf alpha plugin push on CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,13 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 1
-    - uses: bufbuild/buf-setup-action@v1
-      with:
-        version: 1.7.0
+#    - uses: bufbuild/buf-setup-action@v1
+#      with:
+#        version: 1.7.0
+    # TODO: Remove this when new Buf CLI is released.
+    - name: Install buf cli
+      run: |
+        go install github.com/bufbuild/buf/cmd/buf@main
     - name: Install Go
       uses: actions/setup-go@v3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,6 @@ jobs:
     - name: Test
       shell: bash
       run: make test DOCKER_ORG="ghcr.io/bufbuild"
+    - name: Push
+      shell: bash
+      run: make push DOCKER_ORG="ghcr.io/bufbuild" DOCKER_CACHE_ORG="ghcr.io/bufbuild"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,4 +46,6 @@ jobs:
       run: make test DOCKER_ORG="ghcr.io/bufbuild"
     - name: Push
       shell: bash
-      run: make push DOCKER_ORG="ghcr.io/bufbuild" DOCKER_CACHE_ORG="ghcr.io/bufbuild"
+      run: |
+        echo ${BSR_TOKEN} | buf registry login --username ${BSR_USER} --token-stdin
+        make push DOCKER_ORG="ghcr.io/bufbuild" DOCKER_CACHE_ORG="ghcr.io/bufbuild"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,6 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 1
-#    - uses: bufbuild/buf-setup-action@v1
-#      with:
-#        version: 1.7.0
-    # TODO: Remove this when new Buf CLI is released.
-    - name: Install buf cli
-      run: |
-        go install github.com/bufbuild/buf/cmd/buf@main
     - name: Install Go
       uses: actions/setup-go@v3
       with:
@@ -33,6 +26,9 @@ jobs:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-plugins-ci-${{ hashFiles('**/go.sum') }}
         restore-keys: ${{ runner.os }}-plugins-ci
+    - name: Install buf cli
+      run: |
+        go install github.com/bufbuild/buf/cmd/buf@main
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
     - name: Set up Docker Buildx

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ push: build
 			CACHE_ARGS=" --cache-from $(DOCKER_CACHE_ORG)/plugins-$${PLUGIN_OWNER}-$${PLUGIN_NAME}:$${PLUGIN_VERSION}"; \
 		fi; \
 		if [[ "$(DOCKER_ORG)" != "bufbuild" ]]; then \
-			docker pull $(DOCKER_ORG)/bufbuild/plugins-$${PLUGIN_OWNER}-$${PLUGIN_NAME}:$${PLUGIN_VERSION} || :; \
+			docker pull $(DOCKER_ORG)/bufbuild/plugins-$${PLUGIN_OWNER}-$${PLUGIN_NAME}:$${PLUGIN_VERSION}; \
 		fi; \
 		echo "Pushing plugin: $${plugin}"; \
 		buf alpha plugin push $${plugin_dir} $(BUF_PLUGIN_PUSH_ARGS)$${CACHE_ARGS} --build-arg DOCKER_ORG="$(DOCKER_ORG)" || exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,16 @@ test:
 push: build
 	@for plugin in $(PLUGIN_YAML_FILES); do \
 		plugin_dir=$$(dirname $${plugin}); \
+		PLUGIN_FULL_NAME=$(shell yq '.name' $${plugin_dir}/buf.plugin.yaml); \
+		PLUGIN_OWNER=`echo "$${PLUGIN_FULL_NAME}" | cut -d '/' -f 2`; \
+		PLUGIN_NAME=`echo "$${PLUGIN_FULL_NAME}" | cut -d '/' -f 3-`; \
+		PLUGIN_VERSION=$(shell yq '.plugin_version' $${plugin_dir}/buf.plugin.yaml); \
+		if [[ -n "$(DOCKER_CACHE_ORG)" ]]; then \
+			CACHE_ARGS=" --cache-from $(DOCKER_CACHE_ORG)/plugins-$${PLUGIN_OWNER}-$${PLUGIN_NAME}:$${PLUGIN_VERSION}"; \
+		fi; \
+		if [[ "$(DOCKER_ORG)" != "bufbuild" ]]; then \
+			docker pull $(DOCKER_ORG)/bufbuild/plugins-$${PLUGIN_OWNER}-$${PLUGIN_NAME}:$${PLUGIN_VERSION} || :; \
+		fi; \
 		echo "Pushing plugin: $${plugin}"; \
-		buf alpha plugin push $${plugin_dir} $(BUF_PLUGIN_PUSH_ARGS) || exit 1; \
+		buf alpha plugin push $${plugin_dir} $(BUF_PLUGIN_PUSH_ARGS)$${CACHE_ARGS} --build-arg DOCKER_ORG="$(DOCKER_ORG)" || exit 1; \
 	done


### PR DESCRIPTION
Update the CI workflow (when changes are pushed to the main branch) to
run the `buf alpha plugin push` command (in dependency order) to push
all plugins to the BSR.