### PR TITLE
Use caret in npm registry peer deps

### DIFF
--- a/library/connect-web/v0.0.10/buf.plugin.yaml
+++ b/library/connect-web/v0.0.10/buf.plugin.yaml
@@ -10,4 +10,4 @@ registry:
     deps:
       # https://www.npmjs.com/package/@bufbuild/connect-web
       - package: "@bufbuild/connect-web"
-        version: "0.0.10"
+        version: "^0.0.10"

--- a/library/connect-web/v0.1.0/buf.plugin.yaml
+++ b/library/connect-web/v0.1.0/buf.plugin.yaml
@@ -10,4 +10,4 @@ registry:
     deps:
       # https://www.npmjs.com/package/@bufbuild/connect-web
       - package: "@bufbuild/connect-web"
-        version: "0.1.0"
+        version: "^0.1.0"

--- a/library/protobuf-es/v0.0.10/buf.plugin.yaml
+++ b/library/protobuf-es/v0.0.10/buf.plugin.yaml
@@ -7,4 +7,4 @@ registry:
     deps:
       # https://www.npmjs.com/package/@bufbuild/protobuf
       - package: "@bufbuild/protobuf"
-        version: "0.0.10"
+        version: "^0.0.10"

--- a/library/protobuf-es/v0.0.9/buf.plugin.yaml
+++ b/library/protobuf-es/v0.0.9/buf.plugin.yaml
@@ -7,4 +7,4 @@ registry:
     deps:
       # https://www.npmjs.com/package/@bufbuild/protobuf
       - package: "@bufbuild/protobuf"
-        version: "0.0.9"
+        version: "^0.0.9"


### PR DESCRIPTION
Chatted with @timostamm today, and something we want to start doing is capturing runtime dependencies with a caret to loosen the acceptable semver range.

There are special rules for pre-v1 and caret, so this would lead to bumps in the the patch version only. But this is the direction we want to go in once the plugin runtime hits v1 anyways.

> Allows changes that do not modify the left-most non-zero digit in the [major, minor, patch] tuple. In other words, this allows patch and minor updates for versions 1.0.0 and above, patch updates for versions 0.X >=0.1.0, and no updates for versions 0.0.X.

Ref: https://docs.npmjs.com/cli/v6/using-npm/semver#caret-ranges-123-025-004

In the BSR NPM registry this is exposed as a peer dependency.