### PR TITLE
Remove pushing all plugins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,12 +44,3 @@ jobs:
     - name: Test
       shell: bash
       run: make test DOCKER_ORG="ghcr.io/bufbuild"
-    - name: Push
-      shell: bash
-      env:
-        BUF_ALPHA_SUPPRESS_WARNINGS: 1
-        BSR_USER: ${{ secrets.BSR_USER }}
-        BSR_TOKEN: ${{ secrets.BSR_TOKEN }}
-      run: |
-        echo ${BSR_TOKEN} | buf registry login --username ${BSR_USER} --token-stdin
-        make push DOCKER_ORG="ghcr.io/bufbuild" DOCKER_CACHE_ORG="ghcr.io/bufbuild"


### PR DESCRIPTION
Continue to build and test _all_ plugins on merge to main, but do not do a subsequent push.