### PR TITLE
stop using Docker inline buildkit cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
     - name: Build
       shell: bash
-      run: make DOCKER_ORG="ghcr.io/bufbuild" DOCKER_CACHE_ORG="ghcr.io/bufbuild" DOCKER_BUILD_EXTRA_ARGS="--build-arg BUILDKIT_INLINE_CACHE=1 --push"
+      run: make DOCKER_ORG="ghcr.io/bufbuild" DOCKER_READ_CACHE_ORG="ghcr.io/bufbuild" DOCKER_WRITE_CACHE_ORG="ghcr.io/bufbuild" DOCKER_BUILD_EXTRA_ARGS="--push"
     - name: Test
       shell: bash
       run: make test DOCKER_ORG="ghcr.io/bufbuild"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -66,7 +66,7 @@ jobs:
         ALL_MODIFIED_FILES: ${{ steps.changed-files.outputs.all_modified_files }}
         ANY_MODIFIED: ${{ steps.changed-files.outputs.any_modified }}
       shell: bash
-      run: make DOCKER_ORG="localhost:5000/bufbuild" DOCKER_CACHE_ORG="ghcr.io/bufbuild" DOCKER_BUILD_EXTRA_ARGS="--build-arg BUILDKIT_INLINE_CACHE=1 --push"
+      run: make DOCKER_ORG="localhost:5000/bufbuild" DOCKER_READ_CACHE_ORG="ghcr.io/bufbuild" DOCKER_BUILD_EXTRA_ARGS="--push"
     - name: Test
       env:
         ALL_MODIFIED_FILES: ${{ steps.changed-files.outputs.all_modified_files }}


### PR DESCRIPTION
Switch from Docker inline buildkit cache to using the registry cache
with a separate image. This allows us to cache more layers (mode=max)
and also hopefully avoid issues seen with unreproducible builds given
the same inputs.