### PR TITLE
update to use dockerhub login

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,11 @@ jobs:
       uses: docker/setup-buildx-action@v2
       with:
         driver-opts: network=host
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Log in to registry
       run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
     - name: Build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,11 @@ jobs:
         uses: docker/setup-buildx-action@v2
         with:
           driver-opts: network=host
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Deploy plugin
         env:
           BUF_ALPHA_SUPPRESS_WARNINGS: 1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -59,6 +59,11 @@ jobs:
       uses: docker/setup-buildx-action@v2
       with:
         driver-opts: network=host
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Log in to registry
       run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
     - name: Build

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .build/
 .idea/
 .vscode/
+node_modules/
 tests/testdata/**/buf.gen.yaml
 tests/testdata/**/gen/
 tests/testdata/**/protoc-gen-plugin

--- a/contrib/chrusty/jsonschema/v1.3.9/Dockerfile
+++ b/contrib/chrusty/jsonschema/v1.3.9/Dockerfile
@@ -2,14 +2,12 @@
 FROM golang:1.19.0-bullseye AS build
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
-WORKDIR /app
 RUN --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 \
     go install -ldflags "-s -w" -trimpath github.com/chrusty/protoc-gen-jsonschema/cmd/protoc-gen-jsonschema@${PLUGIN_VERSION#v}
 
 FROM scratch
-WORKDIR /app
-COPY --from=build --chown=root:root /etc/passwd /etc/passwd
-COPY --from=build --chown=root:root /go/bin/protoc-gen-jsonschema .
+COPY --from=build --link --chown=root:root /etc/passwd /etc/passwd
+COPY --from=build --link --chown=root:root /go/bin/protoc-gen-jsonschema /
 USER nobody
-ENTRYPOINT [ "/app/protoc-gen-jsonschema" ]
+ENTRYPOINT [ "/protoc-gen-jsonschema" ]

--- a/library/connect-go/v0.1.1/Dockerfile
+++ b/library/connect-go/v0.1.1/Dockerfile
@@ -2,14 +2,12 @@
 FROM golang:1.19.0-bullseye AS build
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
-WORKDIR /app
-ENV GOBIN=/app
 RUN --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 \
     go install -ldflags="-s -w" -trimpath github.com/bufbuild/connect-go/cmd/protoc-gen-connect-go@${PLUGIN_VERSION}
 
 FROM scratch
-COPY --from=build --chown=root:root /etc/passwd /etc/passwd
-COPY --from=build /app/protoc-gen-connect-go /
+COPY --from=build --link --chown=root:root /etc/passwd /etc/passwd
+COPY --from=build --link /go/bin/protoc-gen-connect-go /
 USER nobody
 ENTRYPOINT [ "/protoc-gen-connect-go" ]

--- a/library/connect-go/v0.2.0/Dockerfile
+++ b/library/connect-go/v0.2.0/Dockerfile
@@ -2,14 +2,12 @@
 FROM golang:1.19.0-bullseye AS build
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
-WORKDIR /app
-ENV GOBIN=/app
 RUN --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 \
     go install -ldflags="-s -w" -trimpath github.com/bufbuild/connect-go/cmd/protoc-gen-connect-go@${PLUGIN_VERSION}
 
 FROM scratch
-COPY --from=build --chown=root:root /etc/passwd /etc/passwd
-COPY --from=build /app/protoc-gen-connect-go /
+COPY --from=build --link --chown=root:root /etc/passwd /etc/passwd
+COPY --from=build --link /go/bin/protoc-gen-connect-go /
 USER nobody
 ENTRYPOINT [ "/protoc-gen-connect-go" ]

--- a/library/connect-go/v0.3.0/Dockerfile
+++ b/library/connect-go/v0.3.0/Dockerfile
@@ -2,14 +2,12 @@
 FROM golang:1.19.0-bullseye AS build
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
-WORKDIR /app
-ENV GOBIN=/app
 RUN --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 \
     go install -ldflags="-s -w" -trimpath github.com/bufbuild/connect-go/cmd/protoc-gen-connect-go@${PLUGIN_VERSION}
 
 FROM scratch
-COPY --from=build --chown=root:root /etc/passwd /etc/passwd
-COPY --from=build /app/protoc-gen-connect-go /
+COPY --from=build --link --chown=root:root /etc/passwd /etc/passwd
+COPY --from=build --link /go/bin/protoc-gen-connect-go /
 USER nobody
 ENTRYPOINT [ "/protoc-gen-connect-go" ]

--- a/library/connect-go/v0.4.0/Dockerfile
+++ b/library/connect-go/v0.4.0/Dockerfile
@@ -2,14 +2,12 @@
 FROM golang:1.19.0-bullseye AS build
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
-WORKDIR /app
-ENV GOBIN=/app
 RUN --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 \
     go install -ldflags="-s -w" -trimpath github.com/bufbuild/connect-go/cmd/protoc-gen-connect-go@${PLUGIN_VERSION}
 
 FROM scratch
-COPY --from=build --chown=root:root /etc/passwd /etc/passwd
-COPY --from=build /app/protoc-gen-connect-go /
+COPY --from=build --link --chown=root:root /etc/passwd /etc/passwd
+COPY --from=build --link /go/bin/protoc-gen-connect-go /
 USER nobody
 ENTRYPOINT [ "/protoc-gen-connect-go" ]

--- a/library/connect-web/v0.0.10/.dockerignore
+++ b/library/connect-web/v0.0.10/.dockerignore
@@ -1,2 +1,3 @@
 *
 !Dockerfile
+!package*.json

--- a/library/connect-web/v0.0.10/Dockerfile
+++ b/library/connect-web/v0.0.10/Dockerfile
@@ -3,7 +3,8 @@ FROM node:16.17.0-bullseye-slim
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app
-RUN npm install @bufbuild/protoc-gen-connect-web@${PLUGIN_VERSION}
+COPY --link package*.json .
+RUN npm ci
 
 USER nobody
 ENTRYPOINT [ "/app/node_modules/.bin/protoc-gen-connect-web" ]

--- a/library/connect-web/v0.0.10/package-lock.json
+++ b/library/connect-web/v0.0.10/package-lock.json
@@ -1,0 +1,77 @@
+{
+  "name": "plugins-library-connect-web",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "plugins-library-connect-web",
+      "version": "1.0.0",
+      "dependencies": {
+        "@bufbuild/protoc-gen-connect-web": "0.0.10"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-0.0.9.tgz",
+      "integrity": "sha512-sn7Ha93wmew/9mljh70HWRMIT4syxxM0doBPPRxznraV/IQ60bTn+MVfx+t6fIkJIeKt/ReyUSxsQR5XdZZzdw=="
+    },
+    "node_modules/@bufbuild/protoc-gen-connect-web": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protoc-gen-connect-web/-/protoc-gen-connect-web-0.0.10.tgz",
+      "integrity": "sha512-yhUc1FfAieun7GNhAadPMNf41h9tvzoTylpfdeQhGhkOQJN+uont8SodXvBdEZg2cvxvA5VH3dqxFmdEwyy5lw==",
+      "dependencies": {
+        "@bufbuild/protoplugin": "^0.0.9"
+      },
+      "bin": {
+        "protoc-gen-connect-web": "bin/protoc-gen-connect-web"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@bufbuild/connect-web": "^0.0.10",
+        "@bufbuild/protoc-gen-es": "^0.0.9"
+      },
+      "peerDependenciesMeta": {
+        "@bufbuild/connect-web": {
+          "optional": true
+        },
+        "@bufbuild/protoc-gen-es": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@bufbuild/protoplugin": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protoplugin/-/protoplugin-0.0.9.tgz",
+      "integrity": "sha512-elcMfinjFy/H45njR3VccXR6jvKIozvDyrxgI6DDHjxPulNkhudy0s6b9PkCd0c5yeakbrFRpxUffs6J//cXqA==",
+      "dependencies": {
+        "@bufbuild/protobuf": "^0.0.9"
+      }
+    }
+  },
+  "dependencies": {
+    "@bufbuild/protobuf": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-0.0.9.tgz",
+      "integrity": "sha512-sn7Ha93wmew/9mljh70HWRMIT4syxxM0doBPPRxznraV/IQ60bTn+MVfx+t6fIkJIeKt/ReyUSxsQR5XdZZzdw=="
+    },
+    "@bufbuild/protoc-gen-connect-web": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protoc-gen-connect-web/-/protoc-gen-connect-web-0.0.10.tgz",
+      "integrity": "sha512-yhUc1FfAieun7GNhAadPMNf41h9tvzoTylpfdeQhGhkOQJN+uont8SodXvBdEZg2cvxvA5VH3dqxFmdEwyy5lw==",
+      "requires": {
+        "@bufbuild/protoplugin": "^0.0.9"
+      }
+    },
+    "@bufbuild/protoplugin": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protoplugin/-/protoplugin-0.0.9.tgz",
+      "integrity": "sha512-elcMfinjFy/H45njR3VccXR6jvKIozvDyrxgI6DDHjxPulNkhudy0s6b9PkCd0c5yeakbrFRpxUffs6J//cXqA==",
+      "requires": {
+        "@bufbuild/protobuf": "^0.0.9"
+      }
+    }
+  }
+}

--- a/library/connect-web/v0.0.10/package.json
+++ b/library/connect-web/v0.0.10/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "plugins-library-connect-web",
+  "version": "1.0.0",
+  "dependencies": {
+    "@bufbuild/protoc-gen-connect-web": "0.0.10"
+  }
+}

--- a/library/connect-web/v0.1.0/.dockerignore
+++ b/library/connect-web/v0.1.0/.dockerignore
@@ -1,2 +1,3 @@
 *
 !Dockerfile
+!package*.json

--- a/library/connect-web/v0.1.0/Dockerfile
+++ b/library/connect-web/v0.1.0/Dockerfile
@@ -3,7 +3,8 @@ FROM node:16.17.0-bullseye-slim
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app
-RUN npm install @bufbuild/protoc-gen-connect-web@${PLUGIN_VERSION}
+COPY --link package*.json .
+RUN npm ci
 
 USER nobody
 ENTRYPOINT [ "/app/node_modules/.bin/protoc-gen-connect-web" ]

--- a/library/connect-web/v0.1.0/package-lock.json
+++ b/library/connect-web/v0.1.0/package-lock.json
@@ -1,0 +1,77 @@
+{
+  "name": "plugins-library-connect-web",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "plugins-library-connect-web",
+      "version": "1.0.0",
+      "dependencies": {
+        "@bufbuild/protoc-gen-connect-web": "0.1.0"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-0.0.10.tgz",
+      "integrity": "sha512-KAIMq9+zgRms902o6Cwyv9q4+rf1cOlF41QpEPU8lWbyj+QViD7JjG4370Ev9JFJtJr1qO3ZMdjUhglH0gsDrg=="
+    },
+    "node_modules/@bufbuild/protoc-gen-connect-web": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protoc-gen-connect-web/-/protoc-gen-connect-web-0.1.0.tgz",
+      "integrity": "sha512-vcKLX2ZtSRCoNJMM0lgNTqZjWT2tWEdIS/8/gnWOV3i34FF5kuSINjlfPjl/7nbS5kSDvnjxupmVByMe7+rw8A==",
+      "dependencies": {
+        "@bufbuild/protoplugin": "0.0.10"
+      },
+      "bin": {
+        "protoc-gen-connect-web": "bin/protoc-gen-connect-web"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@bufbuild/connect-web": "0.1.0",
+        "@bufbuild/protoc-gen-es": "0.0.10"
+      },
+      "peerDependenciesMeta": {
+        "@bufbuild/connect-web": {
+          "optional": true
+        },
+        "@bufbuild/protoc-gen-es": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@bufbuild/protoplugin": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protoplugin/-/protoplugin-0.0.10.tgz",
+      "integrity": "sha512-cfC5ODqmkVpNNU8zXhZNSwXQgPZcG6Sqbe4d/UqiOyDh1kH6hYVEuqNKXNBRDzQXjwRAeBEi2m4Zp8MpCoP5Ug==",
+      "dependencies": {
+        "@bufbuild/protobuf": "0.0.10"
+      }
+    }
+  },
+  "dependencies": {
+    "@bufbuild/protobuf": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-0.0.10.tgz",
+      "integrity": "sha512-KAIMq9+zgRms902o6Cwyv9q4+rf1cOlF41QpEPU8lWbyj+QViD7JjG4370Ev9JFJtJr1qO3ZMdjUhglH0gsDrg=="
+    },
+    "@bufbuild/protoc-gen-connect-web": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protoc-gen-connect-web/-/protoc-gen-connect-web-0.1.0.tgz",
+      "integrity": "sha512-vcKLX2ZtSRCoNJMM0lgNTqZjWT2tWEdIS/8/gnWOV3i34FF5kuSINjlfPjl/7nbS5kSDvnjxupmVByMe7+rw8A==",
+      "requires": {
+        "@bufbuild/protoplugin": "0.0.10"
+      }
+    },
+    "@bufbuild/protoplugin": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protoplugin/-/protoplugin-0.0.10.tgz",
+      "integrity": "sha512-cfC5ODqmkVpNNU8zXhZNSwXQgPZcG6Sqbe4d/UqiOyDh1kH6hYVEuqNKXNBRDzQXjwRAeBEi2m4Zp8MpCoP5Ug==",
+      "requires": {
+        "@bufbuild/protobuf": "0.0.10"
+      }
+    }
+  }
+}

--- a/library/connect-web/v0.1.0/package.json
+++ b/library/connect-web/v0.1.0/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "plugins-library-connect-web",
+  "version": "1.0.0",
+  "dependencies": {
+    "@bufbuild/protoc-gen-connect-web": "0.1.0"
+  }
+}

--- a/library/dart/v20.0.1/Dockerfile
+++ b/library/dart/v20.0.1/Dockerfile
@@ -6,15 +6,14 @@ RUN test -n "${PLUGIN_VERSION}"
 ENV PLUGIN_VERSION=${PLUGIN_VERSION}
 
 WORKDIR /build
-RUN ["/bin/bash", "-c", "curl -fsSL https://pub.dartlang.org/packages/protoc_plugin/versions/${PLUGIN_VERSION#v}.tar.gz --compressed -o protoc_plugin.tar.gz"]
-RUN tar -xvf protoc_plugin.tar.gz
-RUN dart pub get
-RUN dart compile exe bin/protoc_plugin.dart -o protoc-gen-dart
+RUN curl -fsSL https://pub.dartlang.org/packages/protoc_plugin/versions/${PLUGIN_VERSION#v}.tar.gz --compressed -o protoc_plugin.tar.gz \
+ && tar -xvf protoc_plugin.tar.gz \
+ && dart pub get \
+ && dart compile exe bin/protoc_plugin.dart -o protoc-gen-dart
 
 FROM scratch
-WORKDIR /build
-COPY --from=build /etc/passwd /etc/passwd
-COPY --from=build /runtime/ /
-COPY --from=build /build/protoc-gen-dart .
+COPY --from=build --link /etc/passwd /etc/passwd
+COPY --from=build --link /runtime/ /
+COPY --from=build --link /build/protoc-gen-dart .
 USER nobody
-ENTRYPOINT [ "./protoc-gen-dart" ]
+ENTRYPOINT [ "/protoc-gen-dart" ]

--- a/library/go/v1.28.0/Dockerfile
+++ b/library/go/v1.28.0/Dockerfile
@@ -2,14 +2,12 @@
 FROM golang:1.19.0-bullseye AS build
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
-WORKDIR /app
 RUN --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 \
     go install -ldflags "-s -w" -trimpath google.golang.org/protobuf/cmd/protoc-gen-go@${PLUGIN_VERSION}
 
 FROM scratch
-WORKDIR /app
-COPY --from=build /etc/passwd /etc/passwd
-COPY --from=build --chown=root:root /go/bin/protoc-gen-go .
+COPY --from=build --link /etc/passwd /etc/passwd
+COPY --from=build --link --chown=root:root /go/bin/protoc-gen-go .
 USER nobody
-ENTRYPOINT [ "/app/protoc-gen-go" ]
+ENTRYPOINT [ "/protoc-gen-go" ]

--- a/library/go/v1.28.1/Dockerfile
+++ b/library/go/v1.28.1/Dockerfile
@@ -2,14 +2,12 @@
 FROM golang:1.19.0-bullseye AS build
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
-WORKDIR /app
 RUN --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 \
     go install -ldflags "-s -w" -trimpath google.golang.org/protobuf/cmd/protoc-gen-go@${PLUGIN_VERSION}
 
 FROM scratch
-WORKDIR /app
-COPY --from=build /etc/passwd /etc/passwd
-COPY --from=build --chown=root:root /go/bin/protoc-gen-go .
+COPY --from=build --link /etc/passwd /etc/passwd
+COPY --from=build --link --chown=root:root /go/bin/protoc-gen-go .
 USER nobody
-ENTRYPOINT [ "/app/protoc-gen-go" ]
+ENTRYPOINT [ "/protoc-gen-go" ]

--- a/library/grpc-go/v1.2.0/Dockerfile
+++ b/library/grpc-go/v1.2.0/Dockerfile
@@ -2,14 +2,12 @@
 FROM golang:1.19.0-bullseye AS build
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
-WORKDIR /app
 RUN --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 \
     go install -ldflags "-s -w" -trimpath google.golang.org/grpc/cmd/protoc-gen-go-grpc@${PLUGIN_VERSION}
 
 FROM scratch
-WORKDIR /app
-COPY --from=build /etc/passwd /etc/passwd
-COPY --from=build --chown=root:root /go/bin/protoc-gen-go-grpc .
+COPY --from=build --link /etc/passwd /etc/passwd
+COPY --from=build --link --chown=root:root /go/bin/protoc-gen-go-grpc .
 USER nobody
-ENTRYPOINT [ "/app/protoc-gen-go-grpc" ]
+ENTRYPOINT [ "/protoc-gen-go-grpc" ]

--- a/library/grpc-java/v1.48.1/Dockerfile
+++ b/library/grpc-java/v1.48.1/Dockerfile
@@ -19,7 +19,6 @@ RUN arch=${TARGETARCH}; \
     curl -fsSL -o protoc-gen-grpc-java https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/${PLUGIN_VERSION#v}/protoc-gen-grpc-java-${PLUGIN_VERSION#v}-linux-${arch}.exe
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 --chown=root:root /build/protoc-gen-grpc-java .
+COPY --from=build --link --chmod=0755 --chown=root:root /build/protoc-gen-grpc-java .
 USER nobody
-ENTRYPOINT [ "/app/protoc-gen-grpc-java" ]
+ENTRYPOINT [ "/protoc-gen-grpc-java" ]

--- a/library/grpc-java/v1.49.0/Dockerfile
+++ b/library/grpc-java/v1.49.0/Dockerfile
@@ -19,7 +19,6 @@ RUN arch=${TARGETARCH}; \
     curl -fsSL -o protoc-gen-grpc-java https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/${PLUGIN_VERSION#v}/protoc-gen-grpc-java-${PLUGIN_VERSION#v}-linux-${arch}.exe
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 --chown=root:root /build/protoc-gen-grpc-java .
+COPY --from=build --link --chmod=0755 --chown=root:root /build/protoc-gen-grpc-java .
 USER nobody
-ENTRYPOINT [ "/app/protoc-gen-grpc-java" ]
+ENTRYPOINT [ "/protoc-gen-grpc-java" ]

--- a/library/grpc-kotlin/v1.3.0/Dockerfile
+++ b/library/grpc-kotlin/v1.3.0/Dockerfile
@@ -12,11 +12,10 @@ RUN apt-get update \
 RUN curl -fsSL -o protoc-gen-grpc-kotlin.jar https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-kotlin/${PLUGIN_VERSION#v}/protoc-gen-grpc-kotlin-${PLUGIN_VERSION#v}-jdk8.jar
 
 FROM eclipse-temurin:17.0.4_8-jre-jammy
-WORKDIR /app
-COPY --from=build --chmod=0644 --chown=root:root /build/protoc-gen-grpc-kotlin.jar .
-COPY --chmod=0755 --chown=root:root <<'EOF' /entrypoint.sh
+COPY --from=build --link --chmod=0644 --chown=root:root /build/protoc-gen-grpc-kotlin.jar .
+COPY --chmod=0755 --link --chown=root:root <<'EOF' /entrypoint.sh
 #!/bin/bash
-exec java -jar /app/protoc-gen-grpc-kotlin.jar "$@"
+exec java -jar /protoc-gen-grpc-kotlin.jar "$@"
 EOF
 USER nobody
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/library/grpc-node/v1.11.2/.dockerignore
+++ b/library/grpc-node/v1.11.2/.dockerignore
@@ -1,2 +1,3 @@
 *
 !Dockerfile
+!package*.json

--- a/library/grpc-node/v1.11.2/Dockerfile
+++ b/library/grpc-node/v1.11.2/Dockerfile
@@ -25,7 +25,6 @@ fi
 EOF
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 --chown=root:root /build/grpc_node_plugin .
+COPY --from=build --link --chmod=0755 --chown=root:root /build/grpc_node_plugin .
 USER nobody
-ENTRYPOINT [ "/app/grpc_node_plugin" ]
+ENTRYPOINT [ "/grpc_node_plugin" ]

--- a/library/grpc-node/v1.11.2/Dockerfile
+++ b/library/grpc-node/v1.11.2/Dockerfile
@@ -7,6 +7,7 @@ RUN test -n "${PLUGIN_VERSION}"
 ARG TARGETARCH
 
 WORKDIR /build
+COPY --link package* .
 RUN /bin/bash <<'EOF'
 set -e
 # https://github.com/grpc/grpc-node/issues/1405#issuecomment-1195903603 - linux/arm64 binaries not available
@@ -19,7 +20,7 @@ if [ "${TARGETARCH}" = "arm64" ]; then
     cmake linux_64bit.toolchain.cmake . && cmake --build . --target clean && cmake --build . -- -j 12
     cp grpc_node_plugin /build
 else
-    npm install grpc-tools@${PLUGIN_VERSION#v}
+    npm ci
     cp /build/node_modules/grpc-tools/bin/grpc_node_plugin /build
 fi
 EOF

--- a/library/grpc-node/v1.11.2/package-lock.json
+++ b/library/grpc-node/v1.11.2/package-lock.json
@@ -1,0 +1,981 @@
+{
+  "name": "plugins-library-grpc-node",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "plugins-library-grpc-node",
+      "version": "1.0.0",
+      "dependencies": {
+        "grpc-tools": "1.11.2"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.9.tgz",
+      "integrity": "sha512-aDF3S3rK9Q2gey/WAttUlISduDItz5BU3306M9Eyv6/oS40aMprnopshtlKTykxRNIBEZuRMaZAnbrQ4QtKGyw==",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aproba": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+    },
+    "node_modules/gauge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
+        "signal-exit": "^3.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/grpc-tools": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/grpc-tools/-/grpc-tools-1.11.2.tgz",
+      "integrity": "sha512-4+EgpnnkJraamY++oyBCw5Hp9huRYfgakjNVKbiE3PgO9Tv5ydVlRo7ZyGJ0C0SEiA7HhbVc1sNNtIyK7FiEtg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^1.0.5"
+      },
+      "bin": {
+        "grpc_tools_node_protoc": "bin/protoc.js",
+        "grpc_tools_node_protoc_plugin": "bin/protoc_plugin.js"
+      }
+    },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
+      "integrity": "sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npmlog": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+      "dependencies": {
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar": {
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^3.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    }
+  },
+  "dependencies": {
+    "@mapbox/node-pre-gyp": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.9.tgz",
+      "integrity": "sha512-aDF3S3rK9Q2gey/WAttUlISduDItz5BU3306M9Eyv6/oS40aMprnopshtlKTykxRNIBEZuRMaZAnbrQ4QtKGyw==",
+      "requires": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      }
+    },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "requires": {
+        "debug": "4"
+      }
+    },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+    },
+    "aproba": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
+    },
+    "are-we-there-yet": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
+    },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
+    },
+    "debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
+    },
+    "detect-libc": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w=="
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+    },
+    "gauge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+      "requires": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
+        "signal-exit": "^3.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.2"
+      }
+    },
+    "glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "grpc-tools": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/grpc-tools/-/grpc-tools-1.11.2.tgz",
+      "integrity": "sha512-4+EgpnnkJraamY++oyBCw5Hp9huRYfgakjNVKbiE3PgO9Tv5ydVlRo7ZyGJ0C0SEiA7HhbVc1sNNtIyK7FiEtg==",
+      "requires": {
+        "@mapbox/node-pre-gyp": "^1.0.5"
+      }
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
+    },
+    "https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "requires": {
+        "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
+      }
+    },
+    "minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minipass": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
+      "integrity": "sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "requires": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      }
+    },
+    "mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
+    "nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "requires": {
+        "abbrev": "1"
+      }
+    },
+    "npmlog": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+      "requires": {
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
+    },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
+    },
+    "signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
+    "tar": {
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+      "requires": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^3.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      }
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "requires": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    }
+  }
+}

--- a/library/grpc-node/v1.11.2/package.json
+++ b/library/grpc-node/v1.11.2/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "plugins-library-grpc-node",
+  "version": "1.0.0",
+  "dependencies": {
+    "grpc-tools": "1.11.2"
+  }
+}

--- a/library/grpc-swift/v1.9.0/Dockerfile
+++ b/library/grpc-swift/v1.9.0/Dockerfile
@@ -11,7 +11,6 @@ WORKDIR /app/grpc-swift
 RUN swift build -c release --static-swift-stdlib --product protoc-gen-grpc-swift
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build /app/grpc-swift/.build/release/protoc-gen-grpc-swift .
+COPY --from=build --link /app/grpc-swift/.build/release/protoc-gen-grpc-swift .
 USER nobody
-ENTRYPOINT [ "/app/protoc-gen-grpc-swift" ]
+ENTRYPOINT [ "/protoc-gen-grpc-swift" ]

--- a/library/grpc-web/v1.3.1/Dockerfile
+++ b/library/grpc-web/v1.3.1/Dockerfile
@@ -27,7 +27,6 @@ fi
 EOF
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 --chown=root:root /build/protoc-gen-grpc-web .
+COPY --from=build --link --chmod=0755 --chown=root:root /build/protoc-gen-grpc-web .
 USER nobody
-ENTRYPOINT [ "/app/protoc-gen-grpc-web" ]
+ENTRYPOINT [ "/protoc-gen-grpc-web" ]

--- a/library/grpc/v1.48.0/cpp/Dockerfile
+++ b/library/grpc/v1.48.0/cpp/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-grpc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/grpc/grpc_cpp_plugin .
+COPY --from=build --link --chmod=0755 /build/grpc/grpc_cpp_plugin .
 USER nobody
-ENTRYPOINT ["/app/grpc_cpp_plugin"]
+ENTRYPOINT ["/grpc_cpp_plugin"]

--- a/library/grpc/v1.48.0/csharp/Dockerfile
+++ b/library/grpc/v1.48.0/csharp/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-grpc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/grpc/grpc_csharp_plugin .
+COPY --from=build --link --chmod=0755 /build/grpc/grpc_csharp_plugin .
 USER nobody
-ENTRYPOINT ["/app/grpc_csharp_plugin"]
+ENTRYPOINT ["/grpc_csharp_plugin"]

--- a/library/grpc/v1.48.0/objc/Dockerfile
+++ b/library/grpc/v1.48.0/objc/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-grpc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/grpc/grpc_objective_c_plugin .
+COPY --from=build --link --chmod=0755 /build/grpc/grpc_objective_c_plugin .
 USER nobody
-ENTRYPOINT ["/app/grpc_objective_c_plugin"]
+ENTRYPOINT ["/grpc_objective_c_plugin"]

--- a/library/grpc/v1.48.0/php/Dockerfile
+++ b/library/grpc/v1.48.0/php/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-grpc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/grpc/grpc_php_plugin .
+COPY --from=build --link --chmod=0755 /build/grpc/grpc_php_plugin .
 USER nobody
-ENTRYPOINT ["/app/grpc_php_plugin"]
+ENTRYPOINT ["/grpc_php_plugin"]

--- a/library/grpc/v1.48.0/python/Dockerfile
+++ b/library/grpc/v1.48.0/python/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-grpc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/grpc/grpc_python_plugin .
+COPY --from=build --link --chmod=0755 /build/grpc/grpc_python_plugin .
 USER nobody
-ENTRYPOINT ["/app/grpc_python_plugin"]
+ENTRYPOINT ["/grpc_python_plugin"]

--- a/library/grpc/v1.48.0/ruby/Dockerfile
+++ b/library/grpc/v1.48.0/ruby/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-grpc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/grpc/grpc_ruby_plugin .
+COPY --from=build --link --chmod=0755 /build/grpc/grpc_ruby_plugin .
 USER nobody
-ENTRYPOINT ["/app/grpc_ruby_plugin"]
+ENTRYPOINT ["/grpc_ruby_plugin"]

--- a/library/protobuf-es/v0.0.10/.dockerignore
+++ b/library/protobuf-es/v0.0.10/.dockerignore
@@ -1,2 +1,3 @@
 *
 !Dockerfile
+!package*.json

--- a/library/protobuf-es/v0.0.10/Dockerfile
+++ b/library/protobuf-es/v0.0.10/Dockerfile
@@ -3,7 +3,8 @@ FROM node:16.17.0-bullseye-slim
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app
-RUN npm install @bufbuild/protoc-gen-es@${PLUGIN_VERSION}
+COPY --link package*.json .
+RUN npm ci
 
 USER nobody
 ENTRYPOINT [ "/app/node_modules/.bin/protoc-gen-es" ]

--- a/library/protobuf-es/v0.0.10/package-lock.json
+++ b/library/protobuf-es/v0.0.10/package-lock.json
@@ -1,0 +1,73 @@
+{
+  "name": "plugins-library-protobuf-es",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "plugins-library-protobuf-es",
+      "version": "1.0.0",
+      "dependencies": {
+        "@bufbuild/protoc-gen-es": "0.0.10"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-0.0.10.tgz",
+      "integrity": "sha512-KAIMq9+zgRms902o6Cwyv9q4+rf1cOlF41QpEPU8lWbyj+QViD7JjG4370Ev9JFJtJr1qO3ZMdjUhglH0gsDrg=="
+    },
+    "node_modules/@bufbuild/protoc-gen-es": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protoc-gen-es/-/protoc-gen-es-0.0.10.tgz",
+      "integrity": "sha512-RhIEinP4eKyZH7Zr0IkZU8Jhp9kxeiuSHh71K0cAlsp0HR1YdBNJ56GW+1e9nJUV/gmFkbQ3L72X1TaWdZ548A==",
+      "dependencies": {
+        "@bufbuild/protoplugin": "0.0.10"
+      },
+      "bin": {
+        "protoc-gen-es": "bin/protoc-gen-es"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "0.0.10"
+      },
+      "peerDependenciesMeta": {
+        "@bufbuild/protobuf": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@bufbuild/protoplugin": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protoplugin/-/protoplugin-0.0.10.tgz",
+      "integrity": "sha512-cfC5ODqmkVpNNU8zXhZNSwXQgPZcG6Sqbe4d/UqiOyDh1kH6hYVEuqNKXNBRDzQXjwRAeBEi2m4Zp8MpCoP5Ug==",
+      "dependencies": {
+        "@bufbuild/protobuf": "0.0.10"
+      }
+    }
+  },
+  "dependencies": {
+    "@bufbuild/protobuf": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-0.0.10.tgz",
+      "integrity": "sha512-KAIMq9+zgRms902o6Cwyv9q4+rf1cOlF41QpEPU8lWbyj+QViD7JjG4370Ev9JFJtJr1qO3ZMdjUhglH0gsDrg=="
+    },
+    "@bufbuild/protoc-gen-es": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protoc-gen-es/-/protoc-gen-es-0.0.10.tgz",
+      "integrity": "sha512-RhIEinP4eKyZH7Zr0IkZU8Jhp9kxeiuSHh71K0cAlsp0HR1YdBNJ56GW+1e9nJUV/gmFkbQ3L72X1TaWdZ548A==",
+      "requires": {
+        "@bufbuild/protoplugin": "0.0.10"
+      }
+    },
+    "@bufbuild/protoplugin": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protoplugin/-/protoplugin-0.0.10.tgz",
+      "integrity": "sha512-cfC5ODqmkVpNNU8zXhZNSwXQgPZcG6Sqbe4d/UqiOyDh1kH6hYVEuqNKXNBRDzQXjwRAeBEi2m4Zp8MpCoP5Ug==",
+      "requires": {
+        "@bufbuild/protobuf": "0.0.10"
+      }
+    }
+  }
+}

--- a/library/protobuf-es/v0.0.10/package.json
+++ b/library/protobuf-es/v0.0.10/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "plugins-library-protobuf-es",
+  "version": "1.0.0",
+  "dependencies": {
+    "@bufbuild/protoc-gen-es": "0.0.10"
+  }
+}

--- a/library/protobuf-es/v0.0.9/.dockerignore
+++ b/library/protobuf-es/v0.0.9/.dockerignore
@@ -1,2 +1,3 @@
 *
 !Dockerfile
+!package*.json

--- a/library/protobuf-es/v0.0.9/Dockerfile
+++ b/library/protobuf-es/v0.0.9/Dockerfile
@@ -3,7 +3,8 @@ FROM node:16.17.0-bullseye-slim
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app
-RUN npm install @bufbuild/protoc-gen-es@${PLUGIN_VERSION}
+COPY --link package*.json .
+RUN npm ci
 
 USER nobody
 ENTRYPOINT [ "/app/node_modules/.bin/protoc-gen-es" ]

--- a/library/protobuf-es/v0.0.9/package-lock.json
+++ b/library/protobuf-es/v0.0.9/package-lock.json
@@ -1,0 +1,73 @@
+{
+  "name": "plugins-library-protobuf-es",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "plugins-library-protobuf-es",
+      "version": "1.0.0",
+      "dependencies": {
+        "@bufbuild/protoc-gen-es": "0.0.9"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-0.0.9.tgz",
+      "integrity": "sha512-sn7Ha93wmew/9mljh70HWRMIT4syxxM0doBPPRxznraV/IQ60bTn+MVfx+t6fIkJIeKt/ReyUSxsQR5XdZZzdw=="
+    },
+    "node_modules/@bufbuild/protoc-gen-es": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protoc-gen-es/-/protoc-gen-es-0.0.9.tgz",
+      "integrity": "sha512-A4nlwaoS6dCNDf8ohvLOfIm6NJPWUzpjJc46UgzVlmeHLOjZOdSaHLmhMVSnN3kx8WX55rl9ULqtGLG0Ks7PJg==",
+      "dependencies": {
+        "@bufbuild/protoplugin": "^0.0.9"
+      },
+      "bin": {
+        "protoc-gen-es": "bin/protoc-gen-es"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^0.0.9"
+      },
+      "peerDependenciesMeta": {
+        "@bufbuild/protobuf": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@bufbuild/protoplugin": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protoplugin/-/protoplugin-0.0.9.tgz",
+      "integrity": "sha512-elcMfinjFy/H45njR3VccXR6jvKIozvDyrxgI6DDHjxPulNkhudy0s6b9PkCd0c5yeakbrFRpxUffs6J//cXqA==",
+      "dependencies": {
+        "@bufbuild/protobuf": "^0.0.9"
+      }
+    }
+  },
+  "dependencies": {
+    "@bufbuild/protobuf": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-0.0.9.tgz",
+      "integrity": "sha512-sn7Ha93wmew/9mljh70HWRMIT4syxxM0doBPPRxznraV/IQ60bTn+MVfx+t6fIkJIeKt/ReyUSxsQR5XdZZzdw=="
+    },
+    "@bufbuild/protoc-gen-es": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protoc-gen-es/-/protoc-gen-es-0.0.9.tgz",
+      "integrity": "sha512-A4nlwaoS6dCNDf8ohvLOfIm6NJPWUzpjJc46UgzVlmeHLOjZOdSaHLmhMVSnN3kx8WX55rl9ULqtGLG0Ks7PJg==",
+      "requires": {
+        "@bufbuild/protoplugin": "^0.0.9"
+      }
+    },
+    "@bufbuild/protoplugin": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protoplugin/-/protoplugin-0.0.9.tgz",
+      "integrity": "sha512-elcMfinjFy/H45njR3VccXR6jvKIozvDyrxgI6DDHjxPulNkhudy0s6b9PkCd0c5yeakbrFRpxUffs6J//cXqA==",
+      "requires": {
+        "@bufbuild/protobuf": "^0.0.9"
+      }
+    }
+  }
+}

--- a/library/protobuf-es/v0.0.9/package.json
+++ b/library/protobuf-es/v0.0.9/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "plugins-library-protobuf-es",
+  "version": "1.0.0",
+  "dependencies": {
+    "@bufbuild/protoc-gen-es": "0.0.9"
+  }
+}

--- a/library/protobuf-es/v0.1.0/.dockerignore
+++ b/library/protobuf-es/v0.1.0/.dockerignore
@@ -1,2 +1,3 @@
 *
 !Dockerfile
+!package*.json

--- a/library/protobuf-es/v0.1.0/Dockerfile
+++ b/library/protobuf-es/v0.1.0/Dockerfile
@@ -3,7 +3,8 @@ FROM node:16.17.0-bullseye-slim
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app
-RUN npm install @bufbuild/protoc-gen-es@${PLUGIN_VERSION}
+COPY --link package*.json .
+RUN npm ci
 
 USER nobody
 ENTRYPOINT [ "/app/node_modules/.bin/protoc-gen-es" ]

--- a/library/protobuf-es/v0.1.0/package-lock.json
+++ b/library/protobuf-es/v0.1.0/package-lock.json
@@ -1,0 +1,73 @@
+{
+  "name": "plugins-library-protobuf-es",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "plugins-library-protobuf-es",
+      "version": "1.0.0",
+      "dependencies": {
+        "@bufbuild/protoc-gen-es": "0.1.0"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-0.1.0.tgz",
+      "integrity": "sha512-LY29YLjJBh6K2Ao2yxaRohQh0HSVsNaKfp19QPcHHUUTV60eiOmD3j9YofOCCoDskooeLLlefBBKzNUYwUHcBg=="
+    },
+    "node_modules/@bufbuild/protoc-gen-es": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protoc-gen-es/-/protoc-gen-es-0.1.0.tgz",
+      "integrity": "sha512-uZw3A/qSaSHab3tlWtQICV+xXMyoE63GiWJJNoLtvdMlSVU3VhiXQ8OBUsxMffMVccJ303ogmJdZECQwZqm+xQ==",
+      "dependencies": {
+        "@bufbuild/protoplugin": "0.1.0"
+      },
+      "bin": {
+        "protoc-gen-es": "bin/protoc-gen-es"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@bufbuild/protobuf": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@bufbuild/protoplugin": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protoplugin/-/protoplugin-0.1.0.tgz",
+      "integrity": "sha512-WvaR1J4mxe1KDmAkWK5YPR5LMKhqld/UGqP32zGE+I0lLE9Bj7b6a0nCk8dmmfMt2aLQvocy1Pyv23dfUaYZtg==",
+      "dependencies": {
+        "@bufbuild/protobuf": "0.1.0"
+      }
+    }
+  },
+  "dependencies": {
+    "@bufbuild/protobuf": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-0.1.0.tgz",
+      "integrity": "sha512-LY29YLjJBh6K2Ao2yxaRohQh0HSVsNaKfp19QPcHHUUTV60eiOmD3j9YofOCCoDskooeLLlefBBKzNUYwUHcBg=="
+    },
+    "@bufbuild/protoc-gen-es": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protoc-gen-es/-/protoc-gen-es-0.1.0.tgz",
+      "integrity": "sha512-uZw3A/qSaSHab3tlWtQICV+xXMyoE63GiWJJNoLtvdMlSVU3VhiXQ8OBUsxMffMVccJ303ogmJdZECQwZqm+xQ==",
+      "requires": {
+        "@bufbuild/protoplugin": "0.1.0"
+      }
+    },
+    "@bufbuild/protoplugin": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protoplugin/-/protoplugin-0.1.0.tgz",
+      "integrity": "sha512-WvaR1J4mxe1KDmAkWK5YPR5LMKhqld/UGqP32zGE+I0lLE9Bj7b6a0nCk8dmmfMt2aLQvocy1Pyv23dfUaYZtg==",
+      "requires": {
+        "@bufbuild/protobuf": "0.1.0"
+      }
+    }
+  }
+}

--- a/library/protobuf-es/v0.1.0/package.json
+++ b/library/protobuf-es/v0.1.0/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "plugins-library-protobuf-es",
+  "version": "1.0.0",
+  "dependencies": {
+    "@bufbuild/protoc-gen-es": "0.1.0"
+  }
+}

--- a/library/protoc/base-build/Dockerfile
+++ b/library/protoc/base-build/Dockerfile
@@ -12,4 +12,4 @@ RUN arch=${TARGETARCH}; \
  && chmod +x /usr/local/bin/bazel
 
 WORKDIR /build
-COPY plugins plugins
+COPY --link plugins plugins

--- a/library/protoc/v21.3/base/Dockerfile
+++ b/library/protoc/v21.3/base/Dockerfile
@@ -8,5 +8,5 @@ RUN test -n "${VERSION}"
 
 RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch ${VERSION} --recursive
 WORKDIR /build/protobuf/
-RUN ["ln", "-s", "/build/plugins", "."]
-RUN ["/bin/bash", "-c", "bazel build $(bazel query 'kind(cc_binary, //plugins/...)')"]
+RUN ln -s /build/plugins .
+RUN bazel build $(bazel query 'kind(cc_binary, //plugins/...)')

--- a/library/protoc/v21.3/cpp/Dockerfile
+++ b/library/protoc/v21.3/cpp/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-cpp .
+COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-cpp .
 USER nobody
-ENTRYPOINT ["/app/protoc-gen-cpp"]
+ENTRYPOINT ["/protoc-gen-cpp"]

--- a/library/protoc/v21.3/csharp/Dockerfile
+++ b/library/protoc/v21.3/csharp/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-csharp .
+COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-csharp .
 USER nobody
-ENTRYPOINT ["/app/protoc-gen-csharp"]
+ENTRYPOINT ["/protoc-gen-csharp"]

--- a/library/protoc/v21.3/java/Dockerfile
+++ b/library/protoc/v21.3/java/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-java .
+COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-java .
 USER nobody
-ENTRYPOINT ["/app/protoc-gen-java"]
+ENTRYPOINT ["/protoc-gen-java"]

--- a/library/protoc/v21.3/kotlin/Dockerfile
+++ b/library/protoc/v21.3/kotlin/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-kotlin .
+COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-kotlin .
 USER nobody
-ENTRYPOINT ["/app/protoc-gen-kotlin"]
+ENTRYPOINT ["/protoc-gen-kotlin"]

--- a/library/protoc/v21.3/objc/Dockerfile
+++ b/library/protoc/v21.3/objc/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-objectivec .
+COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-objectivec .
 USER nobody
-ENTRYPOINT ["/app/protoc-gen-objectivec"]
+ENTRYPOINT ["/protoc-gen-objectivec"]

--- a/library/protoc/v21.3/php/Dockerfile
+++ b/library/protoc/v21.3/php/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-php .
+COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-php .
 USER nobody
-ENTRYPOINT ["/app/protoc-gen-php"]
+ENTRYPOINT ["/protoc-gen-php"]

--- a/library/protoc/v21.3/python/Dockerfile
+++ b/library/protoc/v21.3/python/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-python .
+COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-python .
 USER nobody
-ENTRYPOINT ["/app/protoc-gen-python"]
+ENTRYPOINT ["/protoc-gen-python"]

--- a/library/protoc/v21.3/ruby/Dockerfile
+++ b/library/protoc/v21.3/ruby/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-ruby .
+COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-ruby .
 USER nobody
-ENTRYPOINT ["/app/protoc-gen-ruby"]
+ENTRYPOINT ["/protoc-gen-ruby"]

--- a/library/protoc/v21.4/base/Dockerfile
+++ b/library/protoc/v21.4/base/Dockerfile
@@ -8,5 +8,5 @@ RUN test -n "${VERSION}"
 
 RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch ${VERSION} --recursive
 WORKDIR /build/protobuf/
-RUN ["ln", "-s", "/build/plugins", "."]
-RUN ["/bin/bash", "-c", "bazel build $(bazel query 'kind(cc_binary, //plugins/...)')"]
+RUN ln -s /build/plugins .
+RUN bazel build $(bazel query 'kind(cc_binary, //plugins/...)')

--- a/library/protoc/v21.4/cpp/Dockerfile
+++ b/library/protoc/v21.4/cpp/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-cpp .
+COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-cpp .
 USER nobody
-ENTRYPOINT ["/app/protoc-gen-cpp"]
+ENTRYPOINT ["/protoc-gen-cpp"]

--- a/library/protoc/v21.4/csharp/Dockerfile
+++ b/library/protoc/v21.4/csharp/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-csharp .
+COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-csharp .
 USER nobody
-ENTRYPOINT ["/app/protoc-gen-csharp"]
+ENTRYPOINT ["/protoc-gen-csharp"]

--- a/library/protoc/v21.4/java/Dockerfile
+++ b/library/protoc/v21.4/java/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-java .
+COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-java .
 USER nobody
-ENTRYPOINT ["/app/protoc-gen-java"]
+ENTRYPOINT ["/protoc-gen-java"]

--- a/library/protoc/v21.4/kotlin/Dockerfile
+++ b/library/protoc/v21.4/kotlin/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-kotlin .
+COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-kotlin .
 USER nobody
-ENTRYPOINT ["/app/protoc-gen-kotlin"]
+ENTRYPOINT ["/protoc-gen-kotlin"]

--- a/library/protoc/v21.4/objc/Dockerfile
+++ b/library/protoc/v21.4/objc/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-objectivec .
+COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-objectivec .
 USER nobody
-ENTRYPOINT ["/app/protoc-gen-objectivec"]
+ENTRYPOINT ["/protoc-gen-objectivec"]

--- a/library/protoc/v21.4/php/Dockerfile
+++ b/library/protoc/v21.4/php/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-php .
+COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-php .
 USER nobody
-ENTRYPOINT ["/app/protoc-gen-php"]
+ENTRYPOINT ["/protoc-gen-php"]

--- a/library/protoc/v21.4/python/Dockerfile
+++ b/library/protoc/v21.4/python/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-python .
+COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-python .
 USER nobody
-ENTRYPOINT ["/app/protoc-gen-python"]
+ENTRYPOINT ["/protoc-gen-python"]

--- a/library/protoc/v21.4/ruby/Dockerfile
+++ b/library/protoc/v21.4/ruby/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-ruby .
+COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-ruby .
 USER nobody
-ENTRYPOINT ["/app/protoc-gen-ruby"]
+ENTRYPOINT ["/protoc-gen-ruby"]

--- a/library/protoc/v21.5/base/Dockerfile
+++ b/library/protoc/v21.5/base/Dockerfile
@@ -8,5 +8,5 @@ RUN test -n "${VERSION}"
 
 RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch ${VERSION} --recursive
 WORKDIR /build/protobuf/
-RUN ["ln", "-s", "/build/plugins", "."]
-RUN ["/bin/bash", "-c", "bazel build $(bazel query 'kind(cc_binary, //plugins/...)')"]
+RUN ln -s /build/plugins .
+RUN bazel build $(bazel query 'kind(cc_binary, //plugins/...)')

--- a/library/protoc/v21.5/cpp/Dockerfile
+++ b/library/protoc/v21.5/cpp/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-cpp .
+COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-cpp .
 USER nobody
-ENTRYPOINT ["/app/protoc-gen-cpp"]
+ENTRYPOINT ["/protoc-gen-cpp"]

--- a/library/protoc/v21.5/csharp/Dockerfile
+++ b/library/protoc/v21.5/csharp/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-csharp .
+COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-csharp .
 USER nobody
-ENTRYPOINT ["/app/protoc-gen-csharp"]
+ENTRYPOINT ["/protoc-gen-csharp"]

--- a/library/protoc/v21.5/java/Dockerfile
+++ b/library/protoc/v21.5/java/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-java .
+COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-java .
 USER nobody
-ENTRYPOINT ["/app/protoc-gen-java"]
+ENTRYPOINT ["/protoc-gen-java"]

--- a/library/protoc/v21.5/kotlin/Dockerfile
+++ b/library/protoc/v21.5/kotlin/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-kotlin .
+COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-kotlin .
 USER nobody
-ENTRYPOINT ["/app/protoc-gen-kotlin"]
+ENTRYPOINT ["/protoc-gen-kotlin"]

--- a/library/protoc/v21.5/objc/Dockerfile
+++ b/library/protoc/v21.5/objc/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-objectivec .
+COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-objectivec .
 USER nobody
-ENTRYPOINT ["/app/protoc-gen-objectivec"]
+ENTRYPOINT ["/protoc-gen-objectivec"]

--- a/library/protoc/v21.5/php/Dockerfile
+++ b/library/protoc/v21.5/php/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-php .
+COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-php .
 USER nobody
-ENTRYPOINT ["/app/protoc-gen-php"]
+ENTRYPOINT ["/protoc-gen-php"]

--- a/library/protoc/v21.5/python/Dockerfile
+++ b/library/protoc/v21.5/python/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-python .
+COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-python .
 USER nobody
-ENTRYPOINT ["/app/protoc-gen-python"]
+ENTRYPOINT ["/protoc-gen-python"]

--- a/library/protoc/v21.5/ruby/Dockerfile
+++ b/library/protoc/v21.5/ruby/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-ruby .
+COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-ruby .
 USER nobody
-ENTRYPOINT ["/app/protoc-gen-ruby"]
+ENTRYPOINT ["/protoc-gen-ruby"]

--- a/library/protoc/v3.20.1/base/Dockerfile
+++ b/library/protoc/v3.20.1/base/Dockerfile
@@ -8,6 +8,6 @@ RUN test -n "${VERSION}"
 
 RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch ${VERSION} --recursive
 WORKDIR /build/protobuf/
-COPY plugins/* /build/plugins/
-RUN ["ln", "-s", "/build/plugins", "."]
-RUN ["/bin/bash", "-c", "bazel build $(bazel query 'kind(cc_binary, //plugins/...)')"]
+COPY --link plugins/* /build/plugins/
+RUN ln -s /build/plugins .
+RUN bazel build $(bazel query 'kind(cc_binary, //plugins/...)')

--- a/library/protoc/v3.20.1/cpp/Dockerfile
+++ b/library/protoc/v3.20.1/cpp/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-cpp .
+COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-cpp .
 USER nobody
-ENTRYPOINT ["/app/protoc-gen-cpp"]
+ENTRYPOINT ["/protoc-gen-cpp"]

--- a/library/protoc/v3.20.1/csharp/Dockerfile
+++ b/library/protoc/v3.20.1/csharp/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-csharp .
+COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-csharp .
 USER nobody
-ENTRYPOINT ["/app/protoc-gen-csharp"]
+ENTRYPOINT ["/protoc-gen-csharp"]

--- a/library/protoc/v3.20.1/java/Dockerfile
+++ b/library/protoc/v3.20.1/java/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-java .
+COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-java .
 USER nobody
-ENTRYPOINT ["/app/protoc-gen-java"]
+ENTRYPOINT ["/protoc-gen-java"]

--- a/library/protoc/v3.20.1/js/Dockerfile
+++ b/library/protoc/v3.20.1/js/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-js .
+COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-js .
 USER nobody
-ENTRYPOINT ["/app/protoc-gen-js"]
+ENTRYPOINT ["/protoc-gen-js"]

--- a/library/protoc/v3.20.1/kotlin/Dockerfile
+++ b/library/protoc/v3.20.1/kotlin/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-kotlin .
+COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-kotlin .
 USER nobody
-ENTRYPOINT ["/app/protoc-gen-kotlin"]
+ENTRYPOINT ["/protoc-gen-kotlin"]

--- a/library/protoc/v3.20.1/objc/Dockerfile
+++ b/library/protoc/v3.20.1/objc/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-objectivec .
+COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-objectivec .
 USER nobody
-ENTRYPOINT ["/app/protoc-gen-objectivec"]
+ENTRYPOINT ["/protoc-gen-objectivec"]

--- a/library/protoc/v3.20.1/php/Dockerfile
+++ b/library/protoc/v3.20.1/php/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-php .
+COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-php .
 USER nobody
-ENTRYPOINT ["/app/protoc-gen-php"]
+ENTRYPOINT ["/protoc-gen-php"]

--- a/library/protoc/v3.20.1/python/Dockerfile
+++ b/library/protoc/v3.20.1/python/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-python .
+COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-python .
 USER nobody
-ENTRYPOINT ["/app/protoc-gen-python"]
+ENTRYPOINT ["/protoc-gen-python"]

--- a/library/protoc/v3.20.1/ruby/Dockerfile
+++ b/library/protoc/v3.20.1/ruby/Dockerfile
@@ -4,7 +4,6 @@ ARG DOCKER_ORG=bufbuild
 FROM ${DOCKER_ORG}/plugins-protoc-base:${PLUGIN_VERSION} as build
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-ruby .
+COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-ruby .
 USER nobody
-ENTRYPOINT ["/app/protoc-gen-ruby"]
+ENTRYPOINT ["/protoc-gen-ruby"]

--- a/library/swift/v1.19.0/Dockerfile
+++ b/library/swift/v1.19.0/Dockerfile
@@ -6,12 +6,11 @@ RUN test -n "${PLUGIN_VERSION}"
 ENV PLUGIN_VERSION=${PLUGIN_VERSION}
 
 WORKDIR /app
-RUN ["/bin/bash", "-c", "git clone --depth 1 --branch ${PLUGIN_VERSION#v} https://github.com/apple/swift-protobuf --recursive"]
+RUN git clone --depth 1 --branch ${PLUGIN_VERSION#v} https://github.com/apple/swift-protobuf --recursive
 WORKDIR /app/swift-protobuf
 RUN swift build -c release --static-swift-stdlib
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build /app/swift-protobuf/.build/release/protoc-gen-swift .
+COPY --from=build --link /app/swift-protobuf/.build/release/protoc-gen-swift .
 USER nobody
-ENTRYPOINT [ "/app/protoc-gen-swift" ]
+ENTRYPOINT [ "/protoc-gen-swift" ]

--- a/library/swift/v1.19.1/Dockerfile
+++ b/library/swift/v1.19.1/Dockerfile
@@ -6,12 +6,11 @@ RUN test -n "${PLUGIN_VERSION}"
 ENV PLUGIN_VERSION=${PLUGIN_VERSION}
 
 WORKDIR /app
-RUN ["/bin/bash", "-c", "git clone --depth 1 --branch ${PLUGIN_VERSION#v} https://github.com/apple/swift-protobuf --recursive"]
+RUN git clone --depth 1 --branch ${PLUGIN_VERSION#v} https://github.com/apple/swift-protobuf --recursive
 WORKDIR /app/swift-protobuf
 RUN swift build -c release --static-swift-stdlib
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build /app/swift-protobuf/.build/release/protoc-gen-swift .
+COPY --from=build --link /app/swift-protobuf/.build/release/protoc-gen-swift .
 USER nobody
-ENTRYPOINT [ "/app/protoc-gen-swift" ]
+ENTRYPOINT [ "/protoc-gen-swift" ]

--- a/library/swift/v1.20.0/Dockerfile
+++ b/library/swift/v1.20.0/Dockerfile
@@ -6,12 +6,11 @@ RUN test -n "${PLUGIN_VERSION}"
 ENV PLUGIN_VERSION=${PLUGIN_VERSION}
 
 WORKDIR /app
-RUN ["/bin/bash", "-c", "git clone --depth 1 --branch ${PLUGIN_VERSION#v} https://github.com/apple/swift-protobuf --recursive"]
+RUN git clone --depth 1 --branch ${PLUGIN_VERSION#v} https://github.com/apple/swift-protobuf --recursive
 WORKDIR /app/swift-protobuf
 RUN swift build -c release --static-swift-stdlib
 
 FROM debian:bullseye-20220822-slim
-WORKDIR /app
-COPY --from=build /app/swift-protobuf/.build/release/protoc-gen-swift .
+COPY --from=build --link /app/swift-protobuf/.build/release/protoc-gen-swift .
 USER nobody
-ENTRYPOINT [ "/app/protoc-gen-swift" ]
+ENTRYPOINT [ "/protoc-gen-swift" ]


### PR DESCRIPTION
Update build to use the dockerhub login secrets. Update Dockerfiles to
remove unnecessary layers and use the new copy '--link' flag.