### PR TITLE
attempt to workaround another build issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ test:
 	if [[ -n "$(DOCKER_WRITE_CACHE_ORG)" ]]; then \
 		CACHE_ARGS="$${CACHE_ARGS} --cache-to type=registry,mode=max,ref=$(DOCKER_WRITE_CACHE_ORG)/plugins-grpc-base:$${VERSION}-buildcache"; \
 	fi; \
-	$(DOCKER) $(DOCKER_BUILD_ARGS) $(DOCKER_BUILD_EXTRA_ARGS)$${CACHE_ARGS} --build-arg VERSION=$${VERSION} -t $(DOCKER_ORG)/plugins-grpc-base:$${VERSION} $(<D)
+	$(DOCKER) $(DOCKER_BUILD_ARGS) $(DOCKER_BUILD_EXTRA_ARGS)$${CACHE_ARGS} -t $(DOCKER_ORG)/plugins-grpc-base:$${VERSION} $(<D)
 	@mkdir -p $(dir $@) && touch $@
 
 .build/base/library/protoc/v%/base/image: library/protoc/v%/base/Dockerfile
@@ -64,7 +64,7 @@ test:
 	if [[ -n "$(DOCKER_WRITE_CACHE_ORG)" ]]; then \
 		CACHE_ARGS="$${CACHE_ARGS} --cache-to type=registry,mode=max,ref=$(DOCKER_WRITE_CACHE_ORG)/plugins-protoc-base:$${VERSION}-buildcache"; \
 	fi; \
-	$(DOCKER) $(DOCKER_BUILD_ARGS) $(DOCKER_BUILD_EXTRA_ARGS)$${CACHE_ARGS} --build-arg VERSION=$${VERSION} -t $(DOCKER_ORG)/plugins-protoc-base:$${VERSION} $(<D)
+	$(DOCKER) $(DOCKER_BUILD_ARGS) $(DOCKER_BUILD_EXTRA_ARGS)$${CACHE_ARGS} -t $(DOCKER_ORG)/plugins-protoc-base:$${VERSION} $(<D)
 	@mkdir -p $(dir $@) && touch $@
 
 .build/plugin/%/image: %/Dockerfile %/buf.plugin.yaml $(BASE_IMAGES)

--- a/library/grpc/v1.48.0/base/Dockerfile
+++ b/library/grpc/v1.48.0/base/Dockerfile
@@ -3,10 +3,7 @@ ARG DOCKER_ORG=bufbuild
 ARG BASE_BUILD_VERSION=latest
 FROM ${DOCKER_ORG}/plugins-grpc-base-build:${BASE_BUILD_VERSION}
 
-ARG VERSION
-RUN test -n "${VERSION}"
-
-RUN git clone --depth 1 --branch ${VERSION} --recursive https://github.com/grpc/grpc
+RUN git clone --depth 1 --branch v1.48.0 --recursive https://github.com/grpc/grpc
 WORKDIR /build/grpc
 RUN cmake . \
  && cmake --build . --target plugins

--- a/library/protoc/v21.3/base/Dockerfile
+++ b/library/protoc/v21.3/base/Dockerfile
@@ -3,10 +3,7 @@ ARG DOCKER_ORG=bufbuild
 ARG BASE_BUILD_VERSION=latest
 FROM ${DOCKER_ORG}/plugins-protoc-base-build:${BASE_BUILD_VERSION}
 
-ARG VERSION
-RUN test -n "${VERSION}"
-
-RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch ${VERSION} --recursive
+RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch v21.3 --recursive
 WORKDIR /build/protobuf/
 RUN ln -s /build/plugins .
 RUN bazel build $(bazel query 'kind(cc_binary, //plugins/...)')

--- a/library/protoc/v21.4/base/Dockerfile
+++ b/library/protoc/v21.4/base/Dockerfile
@@ -3,10 +3,7 @@ ARG DOCKER_ORG=bufbuild
 ARG BASE_BUILD_VERSION=latest
 FROM ${DOCKER_ORG}/plugins-protoc-base-build:${BASE_BUILD_VERSION}
 
-ARG VERSION
-RUN test -n "${VERSION}"
-
-RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch ${VERSION} --recursive
+RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch v21.4 --recursive
 WORKDIR /build/protobuf/
 RUN ln -s /build/plugins .
 RUN bazel build $(bazel query 'kind(cc_binary, //plugins/...)')

--- a/library/protoc/v21.5/base/Dockerfile
+++ b/library/protoc/v21.5/base/Dockerfile
@@ -3,10 +3,7 @@ ARG DOCKER_ORG=bufbuild
 ARG BASE_BUILD_VERSION=latest
 FROM ${DOCKER_ORG}/plugins-protoc-base-build:${BASE_BUILD_VERSION}
 
-ARG VERSION
-RUN test -n "${VERSION}"
-
-RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch ${VERSION} --recursive
+RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch v21.5 --recursive
 WORKDIR /build/protobuf/
 RUN ln -s /build/plugins .
 RUN bazel build $(bazel query 'kind(cc_binary, //plugins/...)')

--- a/library/protoc/v3.20.1/base/Dockerfile
+++ b/library/protoc/v3.20.1/base/Dockerfile
@@ -3,10 +3,7 @@ ARG DOCKER_ORG=bufbuild
 ARG BASE_BUILD_VERSION=latest
 FROM ${DOCKER_ORG}/plugins-protoc-base-build:${BASE_BUILD_VERSION}
 
-ARG VERSION
-RUN test -n "${VERSION}"
-
-RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch ${VERSION} --recursive
+RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch v3.20.1 --recursive
 WORKDIR /build/protobuf/
 COPY --link plugins/* /build/plugins/
 RUN ln -s /build/plugins .


### PR DESCRIPTION
Diffing two base layer versions is showing the only changes to the
"created" time for the VERSION arg and the test using it right below.
Remove this and hardcode the version in the base Dockerfile for now to
see if this works around the issue.