### PR TITLE
configure registry opts for grpc-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bufbuild/plugins
 go 1.18
 
 require (
-	github.com/bufbuild/buf v1.7.1-0.20220824233824-e9310457928d
+	github.com/bufbuild/buf v1.7.1-0.20220830155658-0eda16139cac
 	github.com/google/go-github/v45 v45.2.0
 	github.com/hashicorp/go-retryablehttp v0.7.1
 	github.com/sethvargo/go-envconfig v0.8.2

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/bufbuild/buf v1.7.1-0.20220824233824-e9310457928d h1:2nZ9LnpkxjSQvgXAmvFke4muq4lV9NxKYPHbFP47oV8=
 github.com/bufbuild/buf v1.7.1-0.20220824233824-e9310457928d/go.mod h1:e4iSXdNj7xAjkglaowSnGfWwjeaIP3gz+lkGXHdUOC8=
+github.com/bufbuild/buf v1.7.1-0.20220830155658-0eda16139cac h1:jecMGqT37rZhpdgx17bvMqjUTlIQpL99AVz1uQS/eto=
+github.com/bufbuild/buf v1.7.1-0.20220830155658-0eda16139cac/go.mod h1:e4iSXdNj7xAjkglaowSnGfWwjeaIP3gz+lkGXHdUOC8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/library/grpc-go/v1.2.0/buf.plugin.yaml
+++ b/library/grpc-go/v1.2.0/buf.plugin.yaml
@@ -13,3 +13,7 @@ registry:
     deps:
       - module: google.golang.org/grpc
         version: v1.43.0
+  opts:
+    - paths=source_relative
+    - require_unimplemented_servers=false
+    - separate_package=true


### PR DESCRIPTION
Update grpc-go plugin to specify registry opts (including
'separate_package=true').