### PR TITLE
Add custom registry option

### DIFF
--- a/library/connect-web/v0.2.0/buf.plugin.yaml
+++ b/library/connect-web/v0.2.0/buf.plugin.yaml
@@ -6,6 +6,7 @@ description: Simple, reliable, interoperable. A better gRPC-web.
 deps:
   - plugin: buf.build/library/protobuf-es:v0.1.0
 registry:
+  rewrite_import_path_suffix: connectweb.js
   npm:
     deps:
       - package: '@bufbuild/connect-web'

--- a/library/protobuf-es/v0.1.0/buf.plugin.yaml
+++ b/library/protobuf-es/v0.1.0/buf.plugin.yaml
@@ -4,6 +4,7 @@ plugin_version: v0.1.0
 source_url: https://github.com/bufbuild/protobuf-es
 registry:
   npm:
+    rewrite_import_path_suffix: pb.js
     deps:
       # https://www.npmjs.com/package/@bufbuild/protobuf
       - package: "@bufbuild/protobuf"


### PR DESCRIPTION
Custom options these 2 plugins support to output packages to separate directories, when used with the BSR's npm registry.