### PR TITLE
prevent concurrent builds on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 permissions:
   packages: write
 
+concurrency: ci-${{ github.ref }}
+
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Update the ci workflow to use concurrency to ensure that only a single
build is running at a time.