### PR TITLE
always use multi-stage builds for node plugins

### DIFF
--- a/library/connect-web/v0.0.10/Dockerfile
+++ b/library/connect-web/v0.0.10/Dockerfile
@@ -1,10 +1,12 @@
 # syntax=docker/dockerfile:1.4
-FROM node:16.17.0-bullseye-slim
+FROM node:16.17.0-bullseye-slim AS build
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app
 COPY --link package*.json .
 RUN npm ci
 
+FROM node:16.17.0-bullseye-slim
+COPY --link --from=build /app /app
 USER nobody
 ENTRYPOINT [ "/app/node_modules/.bin/protoc-gen-connect-web" ]

--- a/library/connect-web/v0.1.0/Dockerfile
+++ b/library/connect-web/v0.1.0/Dockerfile
@@ -1,10 +1,12 @@
 # syntax=docker/dockerfile:1.4
-FROM node:16.17.0-bullseye-slim
+FROM node:16.17.0-bullseye-slim AS build
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app
 COPY --link package*.json .
 RUN npm ci
 
+FROM node:16.17.0-bullseye-slim
+COPY --link --from=build /app /app
 USER nobody
 ENTRYPOINT [ "/app/node_modules/.bin/protoc-gen-connect-web" ]

--- a/library/connect-web/v0.2.0/Dockerfile
+++ b/library/connect-web/v0.2.0/Dockerfile
@@ -1,10 +1,12 @@
 # syntax=docker/dockerfile:1.4
-FROM node:16.17.0-bullseye-slim
+FROM node:16.17.0-bullseye-slim AS build
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app
 COPY --link package*.json .
 RUN npm ci
 
+FROM node:16.17.0-bullseye-slim
+COPY --link --from=build /app /app
 USER nobody
 ENTRYPOINT [ "/app/node_modules/.bin/protoc-gen-connect-web" ]

--- a/library/protobuf-es/v0.0.10/Dockerfile
+++ b/library/protobuf-es/v0.0.10/Dockerfile
@@ -1,10 +1,12 @@
 # syntax=docker/dockerfile:1.4
-FROM node:16.17.0-bullseye-slim
+FROM node:16.17.0-bullseye-slim AS build
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app
 COPY --link package*.json .
 RUN npm ci
 
+FROM node:16.17.0-bullseye-slim
+COPY --link --from=build /app /app
 USER nobody
 ENTRYPOINT [ "/app/node_modules/.bin/protoc-gen-es" ]

--- a/library/protobuf-es/v0.0.9/Dockerfile
+++ b/library/protobuf-es/v0.0.9/Dockerfile
@@ -1,10 +1,12 @@
 # syntax=docker/dockerfile:1.4
-FROM node:16.17.0-bullseye-slim
+FROM node:16.17.0-bullseye-slim AS build
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app
 COPY --link package*.json .
 RUN npm ci
 
+FROM node:16.17.0-bullseye-slim
+COPY --link --from=build /app /app
 USER nobody
 ENTRYPOINT [ "/app/node_modules/.bin/protoc-gen-es" ]

--- a/library/protobuf-es/v0.1.0/Dockerfile
+++ b/library/protobuf-es/v0.1.0/Dockerfile
@@ -1,10 +1,12 @@
 # syntax=docker/dockerfile:1.4
-FROM node:16.17.0-bullseye-slim
+FROM node:16.17.0-bullseye-slim AS build
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app
 COPY --link package*.json .
 RUN npm ci
 
+FROM node:16.17.0-bullseye-slim
+COPY --link --from=build /app /app
 USER nobody
 ENTRYPOINT [ "/app/node_modules/.bin/protoc-gen-es" ]

--- a/library/protobuf-es/v0.1.1/Dockerfile
+++ b/library/protobuf-es/v0.1.1/Dockerfile
@@ -1,10 +1,12 @@
 # syntax=docker/dockerfile:1.4
-FROM node:16.17.0-bullseye-slim
+FROM node:16.17.0-bullseye-slim AS build
 ARG PLUGIN_VERSION
 RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app
 COPY --link package*.json .
 RUN npm ci
 
+FROM node:16.17.0-bullseye-slim
+COPY --link --from=build /app /app
 USER nobody
 ENTRYPOINT [ "/app/node_modules/.bin/protoc-gen-es" ]


### PR DESCRIPTION
Update node plugins to use a multi-stage build even though we're using package.json/package-lock.json to control dependency versions. There still might be state stored during the `npm ci` operation that we don't want to exist in the final runtime image.

This doesn't make a huge difference but it does reduce the image size by 2-3mb and will hopefully remove additional places where we'll have Docker image build cache misses.