### PR TITLE
allow building/testing specific plugins

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,7 @@ The build requires the following:
 * Run integration tests against Docker images: `make test`.
 * Remove intermediate state from previous builds: `make clean`.
 * Push built plugins to the BSR (currently locked down to CI/CD): `make push`.
+* Build and test an individual plugin: `make PLUGINS="connect-go:v0.4.0" test`.
 
 ## Creating a new plugin
 
@@ -107,7 +108,9 @@ When testing locally, you may wish to build for a different architecture or push
 For example:
 
 ```
-$ make push DOCKER_ORG="bufbuild.internal" BUF_PLUGIN_PUSH_ARGS="--override-remote bufbuild.internal"
+$ make push BUF_PLUGIN_PUSH_ARGS="--override-remote bufbuild.internal"
 ```
 
 This command can also be used to publish to other instances of the BSR.
+This will build with the default architecture of the system by default.
+To specify a different architecture (i.e. x86_64), specify the `DOCKER_BUILD_EXTRA_ARGS="--platform linux/amd64"` argument to the build.

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestWalk(t *testing.T) {
+	t.Parallel()
 	var plugins []*Plugin
 	err := Walk("../..", func(plugin *Plugin) {
 		plugins = append(plugins, plugin)
@@ -20,26 +21,44 @@ func TestWalk(t *testing.T) {
 	assert.NotEmpty(t, plugins)
 }
 
-func TestFilterByChangedFiles(t *testing.T) {
+func TestFilterByPluginsEnv(t *testing.T) {
+	t.Parallel()
 	var plugins []*Plugin
 	err := Walk("../..", func(plugin *Plugin) {
 		plugins = append(plugins, plugin)
 	})
 	require.NoError(t, err)
-	assert.Empty(t, runFilter(t, plugins, nil, false))
-	assert.Len(t, runFilter(t, plugins, []string{"Makefile"}, true), len(plugins))
-	assert.Len(t, runFilter(t, plugins, []string{"tests/plugins_test.go"}, true), len(plugins))
-	assert.Len(t, runFilter(t, plugins, []string{"tests/testdata/images/eliza.bin.gz"}, true), len(plugins))
-	assert.Equal(t, filterPluginsByPathPrefixes(t, plugins, "library/protoc/"), runFilter(t, plugins, []string{"library/protoc/base-build/Dockerfile"}, true))
-	assert.Equal(t, filterPluginsByPathPrefixes(t, plugins, "library/protoc/v21.3/"), runFilter(t, plugins, []string{"library/protoc/v21.3/base/Dockerfile"}, true))
-	assert.Equal(t, filterPluginsByPathPrefixes(t, plugins, "library/protoc/v21.3/cpp/"), runFilter(t, plugins, []string{"tests/testdata/buf.build/library/cpp/v21.3/eliza/plugin.sum"}, true))
+	assert.Empty(t, runFilterByPluginsEnv(t, plugins, "no-match"))
+	assert.Equal(t, filterPluginsByPathPrefixes(t, plugins, "library/connect-go/", "library/connect-web/v0.2.1/"),
+		runFilterByPluginsEnv(t, plugins, "connect-go connect-web:v0.2.1"))
+	assert.Equal(t, filterPluginsByPathPrefixes(t, plugins, "library/connect-go/", "library/connect-web/v0.2.1/"),
+		runFilterByPluginsEnv(t, plugins, "library/connect-go library/connect-web:v0.2.1"))
+	assert.Equal(t, filterPluginsByPathPrefixes(t, plugins, "contrib/chrusty/jsonschema/"),
+		runFilterByPluginsEnv(t, plugins, "chrusty-jsonschema"))
+	assert.Equal(t, filterPluginsByPathPrefixes(t, plugins, "contrib/", "library/"), runFilterByPluginsEnv(t, plugins, ""))
+}
+
+func TestFilterByChangedFiles(t *testing.T) {
+	t.Parallel()
+	var plugins []*Plugin
+	err := Walk("../..", func(plugin *Plugin) {
+		plugins = append(plugins, plugin)
+	})
+	require.NoError(t, err)
+	assert.Empty(t, runFilterByChangedFiles(t, plugins, nil, false))
+	assert.Len(t, runFilterByChangedFiles(t, plugins, []string{"Makefile"}, true), len(plugins))
+	assert.Len(t, runFilterByChangedFiles(t, plugins, []string{"tests/plugins_test.go"}, true), len(plugins))
+	assert.Len(t, runFilterByChangedFiles(t, plugins, []string{"tests/testdata/images/eliza.bin.gz"}, true), len(plugins))
+	assert.Equal(t, filterPluginsByPathPrefixes(t, plugins, "library/protoc/"), runFilterByChangedFiles(t, plugins, []string{"library/protoc/base-build/Dockerfile"}, true))
+	assert.Equal(t, filterPluginsByPathPrefixes(t, plugins, "library/protoc/v21.3/"), runFilterByChangedFiles(t, plugins, []string{"library/protoc/v21.3/base/Dockerfile"}, true))
+	assert.Equal(t, filterPluginsByPathPrefixes(t, plugins, "library/protoc/v21.3/cpp/"), runFilterByChangedFiles(t, plugins, []string{"tests/testdata/buf.build/library/cpp/v21.3/eliza/plugin.sum"}, true))
 	assert.Equal(t,
 		filterPluginsByPathPrefixes(t, plugins,
 			"library/grpc/v1.2.0/",
 			"library/protoc/v21.3/cpp/",
 			"library/protoc/v21.5/java/",
 			"library/connect-go/v0.3.0/",
-		), runFilter(t, plugins,
+		), runFilterByChangedFiles(t, plugins,
 			[]string{
 				"library/connect-go/v0.3.0/buf.plugin.yaml",
 				"library/grpc/v1.2.0/base/Dockerfile",
@@ -59,6 +78,7 @@ func TestGetBaseDockerfiles(t *testing.T) {
 }
 
 func TestGetDockerfiles(t *testing.T) {
+	t.Parallel()
 	var plugins []*Plugin
 	err := Walk("../..", func(plugin *Plugin) {
 		plugins = append(plugins, plugin)
@@ -90,7 +110,18 @@ func indexOf(t *testing.T, haystack []string, needle string) int {
 	panic("unreachable")
 }
 
-func runFilter(t *testing.T, plugins []*Plugin, allModified []string, anyModified bool) []string {
+func runFilterByPluginsEnv(t *testing.T, plugins []*Plugin, pluginsEnv string) []string {
+	t.Helper()
+	filtered, err := FilterByPluginsEnv(plugins, pluginsEnv)
+	require.NoError(t, err)
+	paths := make([]string, 0, len(filtered))
+	for _, plugin := range filtered {
+		paths = append(paths, plugin.Relpath)
+	}
+	return paths
+}
+
+func runFilterByChangedFiles(t *testing.T, plugins []*Plugin, allModified []string, anyModified bool) []string {
 	t.Helper()
 	lookuper := envconfig.MapLookuper(map[string]string{
 		"ALL_MODIFIED_FILES": strings.Join(allModified, ","),

--- a/tests/plugins_test.go
+++ b/tests/plugins_test.go
@@ -138,7 +138,13 @@ func loadPlugins(t *testing.T) []*plugin.Plugin {
 	}); err != nil {
 		t.Fatalf("failed to find plugins: %v", err)
 	}
-	filtered, err := plugin.FilterByChangedFiles(plugins, envconfig.OsLookuper())
+	var filtered []*plugin.Plugin
+	var err error
+	if pluginsEnv := os.Getenv("PLUGINS"); pluginsEnv != "" {
+		filtered, err = plugin.FilterByPluginsEnv(plugins, pluginsEnv)
+	} else {
+		filtered, err = plugin.FilterByChangedFiles(plugins, envconfig.OsLookuper())
+	}
 	require.NoError(t, err)
 	return filtered
 }


### PR DESCRIPTION
Make it easier to build/test/push specific plugins by introducing a new `PLUGINS` argument to the Makefile. For example, to build all versions of connect-go and a single version of protobuf-es, run:

  $ make PLUGINS="connect-go protobuf-es:v0.1.1"

Additionally, update all push targets to use the `--image` flag for consistency.