### PR TITLE
add standalone protobuf-javascript plugin

### DIFF
--- a/library/js/source.yaml
+++ b/library/js/source.yaml
@@ -1,0 +1,4 @@
+source:
+  github:
+    owner: protocolbuffers
+    repository: protobuf-javascript

--- a/library/js/v3.21.0/.dockerignore
+++ b/library/js/v3.21.0/.dockerignore
@@ -1,0 +1,2 @@
+*
+!Dockerfile

--- a/library/js/v3.21.0/Dockerfile
+++ b/library/js/v3.21.0/Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1.4
+FROM debian:bullseye-20220822 AS build
+
+ARG TARGETARCH
+ARG BAZEL_VERSION="4.2.1"
+
+RUN apt-get update \
+ && apt-get install -y curl git cmake build-essential g++ unzip zip
+RUN arch=${TARGETARCH}; \
+    if [ "${arch}" = "amd64" ]; then arch="x86_64"; fi; \
+    curl -fsSL -o /usr/local/bin/bazel https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-${arch} \
+ && chmod +x /usr/local/bin/bazel
+
+WORKDIR /build
+RUN git clone https://github.com/protocolbuffers/protobuf-javascript --depth 1 --branch v3.21.0 --recursive
+WORKDIR /build/protobuf-javascript
+RUN bazel build //generator:protoc-gen-js
+
+FROM debian:bullseye-20220822-slim
+COPY --from=build --link --chmod=0755 /build/protobuf-javascript/bazel-bin/generator/protoc-gen-js .
+USER nobody
+ENTRYPOINT ["/protoc-gen-js"]

--- a/library/js/v3.21.0/buf.plugin.yaml
+++ b/library/js/v3.21.0/buf.plugin.yaml
@@ -1,0 +1,9 @@
+version: v1
+name: buf.build/library/js
+plugin_version: v3.21.0
+output_languages: [javascript]
+source_url: https://github.com/protocolbuffers/protobuf-javascript
+description: Official protobuf plugin for JavaScript.
+default_opts:
+  - import_style=commonjs
+  - binary

--- a/tests/testdata/buf.build/library/js/v3.21.0/eliza/plugin.sum
+++ b/tests/testdata/buf.build/library/js/v3.21.0/eliza/plugin.sum
@@ -1,0 +1,1 @@
+h1:CX2YN2BmPO/kk2aGuNlylO3ZaKAwn04lKmKCWtxgor0=

--- a/tests/testdata/buf.build/library/js/v3.21.0/petapis/plugin.sum
+++ b/tests/testdata/buf.build/library/js/v3.21.0/petapis/plugin.sum
@@ -1,0 +1,1 @@
+h1:6Aq032O277ehpfggXsMPF4RMdhOfe+BsckBharOKJ48=


### PR DESCRIPTION
The protoc JS plugin is moved out of the primary protobuf repository into a separate one. We should create a plugin based on the latest version published there and track any additional updates going forward.