### PR TITLE
remove unused PLUGIN_VERSION argument

### DIFF
--- a/library/connect-web/v0.0.10/Dockerfile
+++ b/library/connect-web/v0.0.10/Dockerfile
@@ -1,7 +1,5 @@
 # syntax=docker/dockerfile:1.4
 FROM node:16.17.0-bullseye-slim AS build
-ARG PLUGIN_VERSION
-RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app
 COPY --link package*.json .
 RUN npm ci

--- a/library/connect-web/v0.1.0/Dockerfile
+++ b/library/connect-web/v0.1.0/Dockerfile
@@ -1,7 +1,5 @@
 # syntax=docker/dockerfile:1.4
 FROM node:16.17.0-bullseye-slim AS build
-ARG PLUGIN_VERSION
-RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app
 COPY --link package*.json .
 RUN npm ci

--- a/library/connect-web/v0.2.0/Dockerfile
+++ b/library/connect-web/v0.2.0/Dockerfile
@@ -1,7 +1,5 @@
 # syntax=docker/dockerfile:1.4
 FROM node:16.17.0-bullseye-slim AS build
-ARG PLUGIN_VERSION
-RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app
 COPY --link package*.json .
 RUN npm ci

--- a/library/connect-web/v0.2.1/Dockerfile
+++ b/library/connect-web/v0.2.1/Dockerfile
@@ -1,7 +1,5 @@
 # syntax=docker/dockerfile:1.4
 FROM node:16.17.0-bullseye-slim AS build
-ARG PLUGIN_VERSION
-RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app
 COPY --link package*.json .
 RUN npm ci

--- a/library/protobuf-es/v0.0.10/Dockerfile
+++ b/library/protobuf-es/v0.0.10/Dockerfile
@@ -1,7 +1,5 @@
 # syntax=docker/dockerfile:1.4
 FROM node:16.17.0-bullseye-slim AS build
-ARG PLUGIN_VERSION
-RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app
 COPY --link package*.json .
 RUN npm ci

--- a/library/protobuf-es/v0.0.9/Dockerfile
+++ b/library/protobuf-es/v0.0.9/Dockerfile
@@ -1,7 +1,5 @@
 # syntax=docker/dockerfile:1.4
 FROM node:16.17.0-bullseye-slim AS build
-ARG PLUGIN_VERSION
-RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app
 COPY --link package*.json .
 RUN npm ci

--- a/library/protobuf-es/v0.1.0/Dockerfile
+++ b/library/protobuf-es/v0.1.0/Dockerfile
@@ -1,7 +1,5 @@
 # syntax=docker/dockerfile:1.4
 FROM node:16.17.0-bullseye-slim AS build
-ARG PLUGIN_VERSION
-RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app
 COPY --link package*.json .
 RUN npm ci

--- a/library/protobuf-es/v0.1.1/Dockerfile
+++ b/library/protobuf-es/v0.1.1/Dockerfile
@@ -1,7 +1,5 @@
 # syntax=docker/dockerfile:1.4
 FROM node:16.17.0-bullseye-slim AS build
-ARG PLUGIN_VERSION
-RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app
 COPY --link package*.json .
 RUN npm ci

--- a/library/twirp-go/v8.1.2/Dockerfile
+++ b/library/twirp-go/v8.1.2/Dockerfile
@@ -1,7 +1,5 @@
 # syntax=docker/dockerfile:1.4
 FROM golang:1.19.1-bullseye AS build
-ARG PLUGIN_VERSION
-RUN test -n "${PLUGIN_VERSION}"
 WORKDIR /app
 COPY --link . /app
 RUN CGO_ENABLED=0 go install -ldflags "-s -w" -trimpath github.com/twitchtv/twirp/protoc-gen-twirp


### PR DESCRIPTION
Update plugins that aren't using PLUGIN_VERSION to remove their usage to minimize chances of re-publishing plugins due to Docker image config JSON changes.