### PR TITLE
only build/test/push changed plugins

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,7 +22,7 @@ jobs:
         fetch-depth: 0
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v29.0.7
+      uses: tj-actions/changed-files@v31
       with:
         files: |
           contrib/**

--- a/.github/workflows/push_all.yml
+++ b/.github/workflows/push_all.yml
@@ -1,7 +1,5 @@
-name: ci
+name: push_all
 on:
-  push:
-    branches: [ "main" ]
   workflow_dispatch: {} # support manual runs
 
 # Ref: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions
@@ -11,40 +9,12 @@ permissions:
 concurrency: ci-${{ github.ref }}
 
 jobs:
-  ci:
+  push_all:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
       with:
-        fetch-depth: 0
-    - name: Get branch name
-      id: branch-name
-      uses: tj-actions/branch-names@v6
-    - uses: nrwl/last-successful-commit-action@v1
-      id: last_successful_commit_push
-      with:
-        branch: ${{ steps.branch-name.outputs.current_branch }}
-        workflow_id: 'ci.yml'
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Get changed files
-      id: changed-files
-      uses: tj-actions/changed-files@v31
-      with:
-        base_sha: ${{ steps.last_successful_commit_push.outputs.commit_hash }}
-        files: |
-          contrib/**
-          library/**
-          tests/*.go
-          tests/testdata/buf.build/**
-          tests/testdata/images/*.gz
-          Makefile
-        files_ignore: |
-          **/source.yaml
-        separator: ","
-    - name: Show changed files
-      run: |
-        echo '${{ toJSON(steps.changed-files.outputs) }}'
-      shell: bash
+        fetch-depth: 1
     - uses: bufbuild/buf-setup-action@v1
       with:
         version: 1.8.0
@@ -74,22 +44,14 @@ jobs:
     - name: Log in to registry
       run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
     - name: Build
-      env:
-        ALL_MODIFIED_FILES: ${{ steps.changed-files.outputs.all_modified_files }}
-        ANY_MODIFIED: ${{ steps.changed-files.outputs.any_modified }}
       shell: bash
       run: make DOCKER_ORG="ghcr.io/bufbuild" DOCKER_READ_CACHE_ORG="ghcr.io/bufbuild" DOCKER_WRITE_CACHE_ORG="ghcr.io/bufbuild" DOCKER_BUILD_EXTRA_ARGS="--push"
     - name: Test
-      env:
-        ALL_MODIFIED_FILES: ${{ steps.changed-files.outputs.all_modified_files }}
-        ANY_MODIFIED: ${{ steps.changed-files.outputs.any_modified }}
       shell: bash
       run: make test DOCKER_ORG="ghcr.io/bufbuild"
     - name: Push
       shell: bash
       env:
-        ALL_MODIFIED_FILES: ${{ steps.changed-files.outputs.all_modified_files }}
-        ANY_MODIFIED: ${{ steps.changed-files.outputs.any_modified }}
         BUF_ALPHA_SUPPRESS_WARNINGS: 1
         BSR_USER: ${{ secrets.BSR_USER }}
         BSR_TOKEN: ${{ secrets.BSR_TOKEN }}


### PR DESCRIPTION
Update the ci workflow to determine which files changed since the last successful build, and only build/test/push the plugins which changed (instead of all of them).