### PR TITLE
only create a single branch for plugin updates

### DIFF
--- a/.github/workflows/fetch_versions.yml
+++ b/.github/workflows/fetch_versions.yml
@@ -25,7 +25,6 @@ jobs:
           add-paths: .
           commit-message: "detected new plugin versions"
           branch: fetch-versions
-          branch-suffix: timestamp
           delete-branch: true
           title: "Found new plugin versions"
           body: "New plugin versions found. Please review."


### PR DESCRIPTION
Don't specify a `branch-suffix` so the default behavior is used (only one branch will be created and it will be updated as needed).