### PR TITLE
configure go module cache before installing buf CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,15 +42,15 @@ jobs:
       with:
         go-version: 1.19.x
         check-latest: true
-    - name: Install buf cli
-      run: |
-        go install github.com/bufbuild/buf/cmd/buf@main
     - name: Cache
       uses: actions/cache@v3
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-plugins-ci-${{ hashFiles('**/go.sum') }}
         restore-keys: ${{ runner.os }}-plugins-ci
+    - name: Install buf cli
+      run: |
+        go install github.com/bufbuild/buf/cmd/buf@main
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
     - name: Set up Docker Buildx

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -48,15 +48,15 @@ jobs:
       with:
         go-version: 1.19.x
         check-latest: true
-    - name: Install buf cli
-      run: |
-        go install github.com/bufbuild/buf/cmd/buf@main
     - name: Cache
       uses: actions/cache@v3
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-plugins-ci-${{ hashFiles('**/go.sum') }}
         restore-keys: ${{ runner.os }}-plugins-ci
+    - name: Install buf cli
+      run: |
+        go install github.com/bufbuild/buf/cmd/buf@main
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
     - name: Set up Docker Buildx

--- a/.github/workflows/push_all.yml
+++ b/.github/workflows/push_all.yml
@@ -20,15 +20,15 @@ jobs:
       with:
         go-version: 1.19.x
         check-latest: true
-    - name: Install buf cli
-      run: |
-        go install github.com/bufbuild/buf/cmd/buf@main
     - name: Cache
       uses: actions/cache@v3
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-plugins-ci-${{ hashFiles('**/go.sum') }}
         restore-keys: ${{ runner.os }}-plugins-ci
+    - name: Install buf cli
+      run: |
+        go install github.com/bufbuild/buf/cmd/buf@main
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
     - name: Set up Docker Buildx


### PR DESCRIPTION
In order to use newer features of the buf CLI that haven't been released yet, we're building the CLI from the main branch. However, we're restoring Go module cache after we install the CLI which means that we're not benefiting from previous builds.

Update the workflows to configure the Go module cache before running 'go install'.