### PR TITLE
Remove grpc/node from dependabot tracked Dockerfiles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,11 +18,6 @@ updates:
     directory: "/plugins/bufbuild/connect-web/v0.2.1"
     schedule:
       interval: "weekly"
-  # node full plugin
-  - package-ecosystem: "docker"
-    directory: "/plugins/grpc/node/v1.11.3"
-    schedule:
-      interval: "weekly"
   # dart plugin
   - package-ecosystem: "docker"
     directory: "/plugins/protocolbuffers/dart/v20.0.1"


### PR DESCRIPTION
We removed this Dockerfile in #153, so the dependabot fails whenever it tries to update this image. (eg
[here](https://github.com/bufbuild/plugins/network/updates/496922854)