### PR TITLE
install buf CLI as part of fetch versions

### DIFF
--- a/.github/workflows/fetch_versions.yml
+++ b/.github/workflows/fetch_versions.yml
@@ -22,6 +22,20 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ steps.generate_token.outputs.token }}
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19.x
+          check-latest: true
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-plugins-fetch-versions-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-plugins-ci
+      - name: Install buf cli
+        run: |
+          go install github.com/bufbuild/buf/cmd/buf@main
       - name: Fetch all versions
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
We use the buf CLI in order to test code generation of newer plugins. Update the workflow to install Go, cache Go modules, and install the latest buf CLI.