### PR TITLE
update fetcher to allow non-zero exit code from diff

### DIFF
--- a/cmd/fetcher/main.go
+++ b/cmd/fetcher/main.go
@@ -173,7 +173,17 @@ func runPluginTests(plugin createdPlugin) error {
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,
 	}
-	return diffCmd.Run()
+	if err := diffCmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			// This is expected if there are differences
+			if exitErr.ExitCode() == 1 {
+				return nil
+			}
+		}
+		return err
+	}
+	return nil
 }
 
 func run(ctx context.Context, root string) ([]createdPlugin, error) {


### PR DESCRIPTION
When we generate diffs from the previous generated code to the new generated code, we should allow the command to return an exit code of 1. Diff will return 1 when there are diffs, 0 when there are no diffs, and anything else if there are other errors.