### PR TITLE
switch to smaller base images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,33 +13,13 @@ updates:
     directory: "/plugins/bufbuild/connect-go/v1.1.0"
     schedule:
       interval: "weekly"
-  # node slim plugin
-  - package-ecosystem: "docker"
-    directory: "/plugins/bufbuild/connect-web/v0.3.1"
-    schedule:
-      interval: "weekly"
-  # node full plugin
-  - package-ecosystem: "docker"
-    directory: "/plugins/grpc/node/v1.11.3"
-    schedule:
-      interval: "weekly"
   # dart plugin
   - package-ecosystem: "docker"
     directory: "/plugins/protocolbuffers/dart/v20.0.1"
     schedule:
       interval: "weekly"
-  # java plugin
-  - package-ecosystem: "docker"
-    directory: "/plugins/grpc/kotlin/v1.3.0"
-    schedule:
-      interval: "weekly"
   # swift plugin
   - package-ecosystem: "docker"
-    directory: "/plugins/apple/swift/v1.20.2"
-    schedule:
-      interval: "weekly"
-  # debian bullseye
-  - package-ecosystem: "docker"
-    directory: "/plugins/protocolbuffers/cpp/v21.9"
+    directory: "/plugins/apple/swift/v1.20.3"
     schedule:
       interval: "weekly"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ This file contains a directory checksum of the generated code for the plugin and
 
 ## Plugin Authoring Best Practices
 
-* Use multi-stage builds to optimize image size. (Recommended to use `scratch` or `debian:bullseye-YYYYMMDD-slim` as runtime images).
+* Use multi-stage builds to optimize image size. (Recommended to use `scratch` or [distroless](https://github.com/GoogleContainerTools/distroless) as runtime images).
 * Always include a [.dockerignore](https://docs.docker.com/engine/reference/builder/#dockerignore-file) alongside the Dockerfile to minimize the Docker build context size (and avoid cache misses during builds). See the following for some examples based on the Protobuf plugin language type:
     * Generic: [plugins/protocolbuffers/go/v1.28.0/.dockerignore](plugins/protocolbuffers/go/v1.28.0/.dockerignore)
     * NPM/Node: [plugins/bufbuild/es/v0.1.1/.dockerignore](plugins/bufbuild/es/v0.1.1/.dockerignore)

--- a/plugins/apple/swift/v1.20.2/Dockerfile
+++ b/plugins/apple/swift/v1.20.2/Dockerfile
@@ -1,12 +1,12 @@
 # syntax=docker/dockerfile:1.4
-FROM swift:5.7.0-focal AS build
+FROM swift:5.7.1-focal AS build
 
 WORKDIR /app
 RUN git clone --depth 1 --branch 1.20.2 https://github.com/apple/swift-protobuf --recursive
 WORKDIR /app/swift-protobuf
-RUN swift build -c release --static-swift-stdlib
+RUN swift build -c release --static-swift-stdlib -Xlinker -s
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link /app/swift-protobuf/.build/release/protoc-gen-swift .
 USER nobody
 ENTRYPOINT [ "/protoc-gen-swift" ]

--- a/plugins/apple/swift/v1.20.3/Dockerfile
+++ b/plugins/apple/swift/v1.20.3/Dockerfile
@@ -4,9 +4,9 @@ FROM swift:5.7.1-focal AS build
 WORKDIR /app
 RUN git clone --depth 1 --branch 1.20.3 https://github.com/apple/swift-protobuf --recursive
 WORKDIR /app/swift-protobuf
-RUN swift build -c release --static-swift-stdlib
+RUN swift build -c release --static-swift-stdlib -Xlinker -s
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link /app/swift-protobuf/.build/release/protoc-gen-swift .
 USER nobody
 ENTRYPOINT [ "/protoc-gen-swift" ]

--- a/plugins/bufbuild/connect-web/v0.2.1/Dockerfile
+++ b/plugins/bufbuild/connect-web/v0.2.1/Dockerfile
@@ -1,10 +1,11 @@
 # syntax=docker/dockerfile:1.4
-FROM node:16.17.1-bullseye-slim AS build
+FROM node:18.12.1-alpine3.16 AS build
 WORKDIR /app
 COPY --link package*.json .
 RUN npm ci
+RUN sed -i -e 's|/usr/bin/env node|/nodejs/bin/node|g' /app/node_modules/@bufbuild/protoc-gen-connect-web/bin/protoc-gen-connect-web
 
-FROM node:16.17.1-bullseye-slim
+FROM gcr.io/distroless/nodejs18-debian11
 COPY --link --from=build /app /app
 USER nobody
 ENTRYPOINT [ "/app/node_modules/.bin/protoc-gen-connect-web" ]

--- a/plugins/bufbuild/connect-web/v0.3.0/Dockerfile
+++ b/plugins/bufbuild/connect-web/v0.3.0/Dockerfile
@@ -1,10 +1,11 @@
 # syntax=docker/dockerfile:1.4
-FROM node:16.18.0-bullseye-slim AS build
+FROM node:18.12.1-alpine3.16 AS build
 WORKDIR /app
 COPY --link package*.json .
 RUN npm ci
+RUN sed -i -e 's|/usr/bin/env node|/nodejs/bin/node|g' /app/node_modules/@bufbuild/protoc-gen-connect-web/bin/protoc-gen-connect-web
 
-FROM node:16.18.0-bullseye-slim
+FROM gcr.io/distroless/nodejs18-debian11
 COPY --link --from=build /app /app
 USER nobody
 ENTRYPOINT [ "/app/node_modules/.bin/protoc-gen-connect-web" ]

--- a/plugins/bufbuild/connect-web/v0.3.1/Dockerfile
+++ b/plugins/bufbuild/connect-web/v0.3.1/Dockerfile
@@ -1,10 +1,11 @@
 # syntax=docker/dockerfile:1.4
-FROM node:18.12.0-bullseye-slim AS build
+FROM node:18.12.1-alpine3.16 AS build
 WORKDIR /app
 COPY --link package*.json .
 RUN npm ci
+RUN sed -i -e 's|/usr/bin/env node|/nodejs/bin/node|g' /app/node_modules/@bufbuild/protoc-gen-connect-web/bin/protoc-gen-connect-web
 
-FROM node:18.12.0-bullseye-slim
+FROM gcr.io/distroless/nodejs18-debian11
 COPY --link --from=build /app /app
 USER nobody
 ENTRYPOINT [ "/app/node_modules/.bin/protoc-gen-connect-web" ]

--- a/plugins/bufbuild/es/v0.1.1/Dockerfile
+++ b/plugins/bufbuild/es/v0.1.1/Dockerfile
@@ -1,10 +1,11 @@
 # syntax=docker/dockerfile:1.4
-FROM node:16.17.1-bullseye-slim AS build
+FROM node:18.12.1-alpine3.16 AS build
 WORKDIR /app
 COPY --link package*.json .
 RUN npm ci
+RUN sed -i -e 's|/usr/bin/env node|/nodejs/bin/node|g' /app/node_modules/@bufbuild/protoc-gen-es/bin/protoc-gen-es
 
-FROM node:16.17.1-bullseye-slim
+FROM gcr.io/distroless/nodejs18-debian11
 COPY --link --from=build /app /app
 USER nobody
 ENTRYPOINT [ "/app/node_modules/.bin/protoc-gen-es" ]

--- a/plugins/bufbuild/es/v0.2.0/Dockerfile
+++ b/plugins/bufbuild/es/v0.2.0/Dockerfile
@@ -1,10 +1,11 @@
 # syntax=docker/dockerfile:1.4
-FROM node:16.18.0-bullseye-slim AS build
+FROM node:18.12.1-alpine3.16 AS build
 WORKDIR /app
 COPY --link package*.json .
 RUN npm ci
+RUN sed -i -e 's|/usr/bin/env node|/nodejs/bin/node|g' /app/node_modules/@bufbuild/protoc-gen-es/bin/protoc-gen-es
 
-FROM node:16.18.0-bullseye-slim
+FROM gcr.io/distroless/nodejs18-debian11
 COPY --link --from=build /app /app
 USER nobody
 ENTRYPOINT [ "/app/node_modules/.bin/protoc-gen-es" ]

--- a/plugins/bufbuild/es/v0.2.1/Dockerfile
+++ b/plugins/bufbuild/es/v0.2.1/Dockerfile
@@ -1,10 +1,11 @@
 # syntax=docker/dockerfile:1.4
-FROM node:18.12.0-bullseye-slim AS build
+FROM node:18.12.1-alpine3.16 AS build
 WORKDIR /app
 COPY --link package*.json .
 RUN npm ci
+RUN sed -i -e 's|/usr/bin/env node|/nodejs/bin/node|g' /app/node_modules/@bufbuild/protoc-gen-es/bin/protoc-gen-es
 
-FROM node:18.12.0-bullseye-slim
+FROM gcr.io/distroless/nodejs18-debian11
 COPY --link --from=build /app /app
 USER nobody
 ENTRYPOINT [ "/app/node_modules/.bin/protoc-gen-es" ]

--- a/plugins/grpc/cpp/v1.50.0/Dockerfile
+++ b/plugins/grpc/cpp/v1.50.0/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114 AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ WORKDIR /build
 RUN git clone --depth 1 --branch v1.50.0 --recursive https://github.com/grpc/grpc
 WORKDIR /build/grpc
 RUN bazel build //src/compiler:grpc_plugin_support
-RUN bazel build //src/compiler:grpc_cpp_plugin
+RUN bazel build //src/compiler:grpc_cpp_plugin.stripped
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/grpc/bazel-bin/src/compiler/grpc_cpp_plugin .
 USER nobody
 ENTRYPOINT ["/grpc_cpp_plugin"]

--- a/plugins/grpc/cpp/v1.50.1/Dockerfile
+++ b/plugins/grpc/cpp/v1.50.1/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114 AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ WORKDIR /build
 RUN git clone --depth 1 --branch v1.50.1 --recursive https://github.com/grpc/grpc
 WORKDIR /build/grpc
 RUN bazel build //src/compiler:grpc_plugin_support
-RUN bazel build //src/compiler:grpc_cpp_plugin
+RUN bazel build //src/compiler:grpc_cpp_plugin.stripped
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/grpc/bazel-bin/src/compiler/grpc_cpp_plugin .
 USER nobody
 ENTRYPOINT ["/grpc_cpp_plugin"]

--- a/plugins/grpc/cpp/v1.51.0/Dockerfile
+++ b/plugins/grpc/cpp/v1.51.0/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114 AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ WORKDIR /build
 RUN git clone --depth 1 --branch v1.51.0 --recursive https://github.com/grpc/grpc
 WORKDIR /build/grpc
 RUN bazel build //src/compiler:grpc_plugin_support
-RUN bazel build //src/compiler:grpc_cpp_plugin
+RUN bazel build //src/compiler:grpc_cpp_plugin.stripped
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/grpc/bazel-bin/src/compiler/grpc_cpp_plugin .
 USER nobody
 ENTRYPOINT ["/grpc_cpp_plugin"]

--- a/plugins/grpc/csharp/v1.50.0/Dockerfile
+++ b/plugins/grpc/csharp/v1.50.0/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114 AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ WORKDIR /build
 RUN git clone --depth 1 --branch v1.50.0 --recursive https://github.com/grpc/grpc
 WORKDIR /build/grpc
 RUN bazel build //src/compiler:grpc_plugin_support
-RUN bazel build //src/compiler:grpc_csharp_plugin
+RUN bazel build //src/compiler:grpc_csharp_plugin.stripped
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/grpc/bazel-bin/src/compiler/grpc_csharp_plugin .
 USER nobody
 ENTRYPOINT ["/grpc_csharp_plugin"]

--- a/plugins/grpc/csharp/v1.50.1/Dockerfile
+++ b/plugins/grpc/csharp/v1.50.1/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114 AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ WORKDIR /build
 RUN git clone --depth 1 --branch v1.50.1 --recursive https://github.com/grpc/grpc
 WORKDIR /build/grpc
 RUN bazel build //src/compiler:grpc_plugin_support
-RUN bazel build //src/compiler:grpc_csharp_plugin
+RUN bazel build //src/compiler:grpc_csharp_plugin.stripped
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/grpc/bazel-bin/src/compiler/grpc_csharp_plugin .
 USER nobody
 ENTRYPOINT ["/grpc_csharp_plugin"]

--- a/plugins/grpc/csharp/v1.51.0/Dockerfile
+++ b/plugins/grpc/csharp/v1.51.0/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114 AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ WORKDIR /build
 RUN git clone --depth 1 --branch v1.51.0 --recursive https://github.com/grpc/grpc
 WORKDIR /build/grpc
 RUN bazel build //src/compiler:grpc_plugin_support
-RUN bazel build //src/compiler:grpc_csharp_plugin
+RUN bazel build //src/compiler:grpc_csharp_plugin.stripped
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/grpc/bazel-bin/src/compiler/grpc_csharp_plugin .
 USER nobody
 ENTRYPOINT ["/grpc_csharp_plugin"]

--- a/plugins/grpc/java/v1.50.0/Dockerfile
+++ b/plugins/grpc/java/v1.50.0/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004-slim AS build
+FROM debian:bullseye-20221114 AS build
 
 ARG TARGETARCH
 
@@ -15,7 +15,7 @@ RUN arch=${TARGETARCH}; \
     echo "${arch}"; \
     curl -fsSL -o protoc-gen-grpc-java https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/1.50.0/protoc-gen-grpc-java-1.50.0-linux-${arch}.exe
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/base-debian11
 COPY --from=build --link --chmod=0755 --chown=root:root /build/protoc-gen-grpc-java .
 USER nobody
 ENTRYPOINT [ "/protoc-gen-grpc-java" ]

--- a/plugins/grpc/java/v1.50.2/Dockerfile
+++ b/plugins/grpc/java/v1.50.2/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004-slim AS build
+FROM debian:bullseye-20221114 AS build
 
 ARG TARGETARCH
 
@@ -15,7 +15,7 @@ RUN arch=${TARGETARCH}; \
     echo "${arch}"; \
     curl -fsSL -o protoc-gen-grpc-java https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/1.50.2/protoc-gen-grpc-java-1.50.2-linux-${arch}.exe
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/base-debian11
 COPY --from=build --link --chmod=0755 --chown=root:root /build/protoc-gen-grpc-java .
 USER nobody
 ENTRYPOINT [ "/protoc-gen-grpc-java" ]

--- a/plugins/grpc/java/v1.51.0/Dockerfile
+++ b/plugins/grpc/java/v1.51.0/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221114-slim AS build
+FROM debian:bullseye-20221114 AS build
 
 ARG TARGETARCH
 
@@ -15,7 +15,7 @@ RUN arch=${TARGETARCH}; \
     echo "${arch}"; \
     curl -fsSL -o protoc-gen-grpc-java https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/1.51.0/protoc-gen-grpc-java-1.51.0-linux-${arch}.exe
 
-FROM debian:bullseye-20221114-slim
+FROM gcr.io/distroless/base-debian11
 COPY --from=build --link --chmod=0755 --chown=root:root /build/protoc-gen-grpc-java .
 USER nobody
 ENTRYPOINT [ "/protoc-gen-grpc-java" ]

--- a/plugins/grpc/kotlin/v1.3.0/Dockerfile
+++ b/plugins/grpc/kotlin/v1.3.0/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update \
  && apt-get install -y curl
 RUN curl -fsSL -o protoc-gen-grpc-kotlin.jar https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-kotlin/1.3.0/protoc-gen-grpc-kotlin-1.3.0-jdk8.jar
 
-FROM gcr.io/distroless/java17-debian11
+FROM gcr.io/distroless/java11-debian11
 COPY --from=build --link --chmod=0644 --chown=root:root /build/protoc-gen-grpc-kotlin.jar .
 USER nobody
-ENTRYPOINT [ "java", "-jar", "/protoc-gen-grpc-kotlin.jar" ]
+ENTRYPOINT [ "/usr/bin/java", "-jar", "/protoc-gen-grpc-kotlin.jar" ]

--- a/plugins/grpc/kotlin/v1.3.0/Dockerfile
+++ b/plugins/grpc/kotlin/v1.3.0/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004-slim AS build
+FROM debian:bullseye-20221114 AS build
 
 ARG TARGETARCH
 
@@ -8,11 +8,7 @@ RUN apt-get update \
  && apt-get install -y curl
 RUN curl -fsSL -o protoc-gen-grpc-kotlin.jar https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-kotlin/1.3.0/protoc-gen-grpc-kotlin-1.3.0-jdk8.jar
 
-FROM eclipse-temurin:17.0.4_8-jre-jammy
+FROM gcr.io/distroless/java17-debian11
 COPY --from=build --link --chmod=0644 --chown=root:root /build/protoc-gen-grpc-kotlin.jar .
-COPY --chmod=0755 --link --chown=root:root <<'EOF' /entrypoint.sh
-#!/bin/bash
-exec java -jar /protoc-gen-grpc-kotlin.jar "$@"
-EOF
 USER nobody
-ENTRYPOINT [ "/entrypoint.sh" ]
+ENTRYPOINT [ "java", "-jar", "/protoc-gen-grpc-kotlin.jar" ]

--- a/plugins/grpc/node/v1.11.3/Dockerfile
+++ b/plugins/grpc/node/v1.11.3/Dockerfile
@@ -22,7 +22,7 @@ else
 fi
 EOF
 
-FROM debian:bullseye-20221024-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 --chown=root:root /build/grpc_node_plugin .
 USER nobody
 ENTRYPOINT [ "/grpc_node_plugin" ]

--- a/plugins/grpc/objc/v1.50.0/Dockerfile
+++ b/plugins/grpc/objc/v1.50.0/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114 AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ WORKDIR /build
 RUN git clone --depth 1 --branch v1.50.0 --recursive https://github.com/grpc/grpc
 WORKDIR /build/grpc
 RUN bazel build //src/compiler:grpc_plugin_support
-RUN bazel build //src/compiler:grpc_objective_c_plugin
+RUN bazel build //src/compiler:grpc_objective_c_plugin.stripped
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/grpc/bazel-bin/src/compiler/grpc_objective_c_plugin .
 USER nobody
 ENTRYPOINT ["/grpc_objective_c_plugin"]

--- a/plugins/grpc/objc/v1.50.1/Dockerfile
+++ b/plugins/grpc/objc/v1.50.1/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114 AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ WORKDIR /build
 RUN git clone --depth 1 --branch v1.50.1 --recursive https://github.com/grpc/grpc
 WORKDIR /build/grpc
 RUN bazel build //src/compiler:grpc_plugin_support
-RUN bazel build //src/compiler:grpc_objective_c_plugin
+RUN bazel build //src/compiler:grpc_objective_c_plugin.stripped
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/grpc/bazel-bin/src/compiler/grpc_objective_c_plugin .
 USER nobody
 ENTRYPOINT ["/grpc_objective_c_plugin"]

--- a/plugins/grpc/objc/v1.51.0/Dockerfile
+++ b/plugins/grpc/objc/v1.51.0/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114 AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ WORKDIR /build
 RUN git clone --depth 1 --branch v1.51.0 --recursive https://github.com/grpc/grpc
 WORKDIR /build/grpc
 RUN bazel build //src/compiler:grpc_plugin_support
-RUN bazel build //src/compiler:grpc_objective_c_plugin
+RUN bazel build //src/compiler:grpc_objective_c_plugin.stripped
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/grpc/bazel-bin/src/compiler/grpc_objective_c_plugin .
 USER nobody
 ENTRYPOINT ["/grpc_objective_c_plugin"]

--- a/plugins/grpc/php/v1.50.0/Dockerfile
+++ b/plugins/grpc/php/v1.50.0/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114 AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ WORKDIR /build
 RUN git clone --depth 1 --branch v1.50.0 --recursive https://github.com/grpc/grpc
 WORKDIR /build/grpc
 RUN bazel build //src/compiler:grpc_plugin_support
-RUN bazel build //src/compiler:grpc_php_plugin
+RUN bazel build //src/compiler:grpc_php_plugin.stripped
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/grpc/bazel-bin/src/compiler/grpc_php_plugin .
 USER nobody
 ENTRYPOINT ["/grpc_php_plugin"]

--- a/plugins/grpc/php/v1.50.1/Dockerfile
+++ b/plugins/grpc/php/v1.50.1/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114 AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ WORKDIR /build
 RUN git clone --depth 1 --branch v1.50.1 --recursive https://github.com/grpc/grpc
 WORKDIR /build/grpc
 RUN bazel build //src/compiler:grpc_plugin_support
-RUN bazel build //src/compiler:grpc_php_plugin
+RUN bazel build //src/compiler:grpc_php_plugin.stripped
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/grpc/bazel-bin/src/compiler/grpc_php_plugin .
 USER nobody
 ENTRYPOINT ["/grpc_php_plugin"]

--- a/plugins/grpc/php/v1.51.0/Dockerfile
+++ b/plugins/grpc/php/v1.51.0/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114 AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ WORKDIR /build
 RUN git clone --depth 1 --branch v1.51.0 --recursive https://github.com/grpc/grpc
 WORKDIR /build/grpc
 RUN bazel build //src/compiler:grpc_plugin_support
-RUN bazel build //src/compiler:grpc_php_plugin
+RUN bazel build //src/compiler:grpc_php_plugin.stripped
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/grpc/bazel-bin/src/compiler/grpc_php_plugin .
 USER nobody
 ENTRYPOINT ["/grpc_php_plugin"]

--- a/plugins/grpc/python/v1.50.0/Dockerfile
+++ b/plugins/grpc/python/v1.50.0/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114 AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ WORKDIR /build
 RUN git clone --depth 1 --branch v1.50.0 --recursive https://github.com/grpc/grpc
 WORKDIR /build/grpc
 RUN bazel build //src/compiler:grpc_plugin_support
-RUN bazel build //src/compiler:grpc_python_plugin
+RUN bazel build //src/compiler:grpc_python_plugin.stripped
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/grpc/bazel-bin/src/compiler/grpc_python_plugin .
 USER nobody
 ENTRYPOINT ["/grpc_python_plugin"]

--- a/plugins/grpc/python/v1.50.1/Dockerfile
+++ b/plugins/grpc/python/v1.50.1/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114 AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ WORKDIR /build
 RUN git clone --depth 1 --branch v1.50.1 --recursive https://github.com/grpc/grpc
 WORKDIR /build/grpc
 RUN bazel build //src/compiler:grpc_plugin_support
-RUN bazel build //src/compiler:grpc_python_plugin
+RUN bazel build //src/compiler:grpc_python_plugin.stripped
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/grpc/bazel-bin/src/compiler/grpc_python_plugin .
 USER nobody
 ENTRYPOINT ["/grpc_python_plugin"]

--- a/plugins/grpc/python/v1.51.0/Dockerfile
+++ b/plugins/grpc/python/v1.51.0/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114 AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ WORKDIR /build
 RUN git clone --depth 1 --branch v1.51.0 --recursive https://github.com/grpc/grpc
 WORKDIR /build/grpc
 RUN bazel build //src/compiler:grpc_plugin_support
-RUN bazel build //src/compiler:grpc_python_plugin
+RUN bazel build //src/compiler:grpc_python_plugin.stripped
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/grpc/bazel-bin/src/compiler/grpc_python_plugin .
 USER nobody
 ENTRYPOINT ["/grpc_python_plugin"]

--- a/plugins/grpc/ruby/v1.50.0/Dockerfile
+++ b/plugins/grpc/ruby/v1.50.0/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114 AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ WORKDIR /build
 RUN git clone --depth 1 --branch v1.50.0 --recursive https://github.com/grpc/grpc
 WORKDIR /build/grpc
 RUN bazel build //src/compiler:grpc_plugin_support
-RUN bazel build //src/compiler:grpc_ruby_plugin
+RUN bazel build //src/compiler:grpc_ruby_plugin.stripped
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/grpc/bazel-bin/src/compiler/grpc_ruby_plugin .
 USER nobody
 ENTRYPOINT ["/grpc_ruby_plugin"]

--- a/plugins/grpc/ruby/v1.50.1/Dockerfile
+++ b/plugins/grpc/ruby/v1.50.1/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114 AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ WORKDIR /build
 RUN git clone --depth 1 --branch v1.50.1 --recursive https://github.com/grpc/grpc
 WORKDIR /build/grpc
 RUN bazel build //src/compiler:grpc_plugin_support
-RUN bazel build //src/compiler:grpc_ruby_plugin
+RUN bazel build //src/compiler:grpc_ruby_plugin.stripped
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/grpc/bazel-bin/src/compiler/grpc_ruby_plugin .
 USER nobody
 ENTRYPOINT ["/grpc_ruby_plugin"]

--- a/plugins/grpc/ruby/v1.51.0/Dockerfile
+++ b/plugins/grpc/ruby/v1.51.0/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114 AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ WORKDIR /build
 RUN git clone --depth 1 --branch v1.51.0 --recursive https://github.com/grpc/grpc
 WORKDIR /build/grpc
 RUN bazel build //src/compiler:grpc_plugin_support
-RUN bazel build //src/compiler:grpc_ruby_plugin
+RUN bazel build //src/compiler:grpc_ruby_plugin.stripped
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/grpc/bazel-bin/src/compiler/grpc_ruby_plugin .
 USER nobody
 ENTRYPOINT ["/grpc_ruby_plugin"]

--- a/plugins/grpc/swift/v1.11.0/Dockerfile
+++ b/plugins/grpc/swift/v1.11.0/Dockerfile
@@ -1,12 +1,12 @@
 # syntax=docker/dockerfile:1.4
-FROM swift:5.7.0-focal AS build
+FROM swift:5.7.1-focal AS build
 
 WORKDIR /app
 RUN git clone --depth 1 --branch 1.11.0 https://github.com/grpc/grpc-swift --recursive
 WORKDIR /app/grpc-swift
-RUN swift build -c release --static-swift-stdlib --product protoc-gen-grpc-swift
+RUN swift build -c release --static-swift-stdlib --product protoc-gen-grpc-swift -Xlinker -s
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link /app/grpc-swift/.build/release/protoc-gen-grpc-swift .
 USER nobody
 ENTRYPOINT [ "/protoc-gen-grpc-swift" ]

--- a/plugins/grpc/swift/v1.12.0/Dockerfile
+++ b/plugins/grpc/swift/v1.12.0/Dockerfile
@@ -1,12 +1,12 @@
 # syntax=docker/dockerfile:1.4
-FROM swift:5.7.0-focal AS build
+FROM swift:5.7.1-focal AS build
 
 WORKDIR /app
 RUN git clone --depth 1 --branch 1.12.0 https://github.com/grpc/grpc-swift --recursive
 WORKDIR /app/grpc-swift
-RUN swift build -c release --static-swift-stdlib --product protoc-gen-grpc-swift
+RUN swift build -c release --static-swift-stdlib --product protoc-gen-grpc-swift -Xlinker -s
 
-FROM debian:bullseye-20221024-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link /app/grpc-swift/.build/release/protoc-gen-grpc-swift .
 USER nobody
 ENTRYPOINT [ "/protoc-gen-grpc-swift" ]

--- a/plugins/grpc/swift/v1.13.0/Dockerfile
+++ b/plugins/grpc/swift/v1.13.0/Dockerfile
@@ -4,9 +4,9 @@ FROM swift:5.7.1-focal AS build
 WORKDIR /app
 RUN git clone --depth 1 --branch 1.13.0 https://github.com/grpc/grpc-swift --recursive
 WORKDIR /app/grpc-swift
-RUN swift build -c release --static-swift-stdlib --product protoc-gen-grpc-swift
+RUN swift build -c release --static-swift-stdlib --product protoc-gen-grpc-swift -Xlinker -s
 
-FROM debian:bullseye-20221024-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link /app/grpc-swift/.build/release/protoc-gen-grpc-swift .
 USER nobody
 ENTRYPOINT [ "/protoc-gen-grpc-swift" ]

--- a/plugins/grpc/web/v1.4.2/Dockerfile
+++ b/plugins/grpc/web/v1.4.2/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221024-slim AS build
+FROM debian:bullseye-20221114 AS build
 
 ARG TARGETARCH
 
@@ -8,7 +8,7 @@ RUN apt-get update \
  && if [ "${TARGETARCH}" = "arm64" ]; then TARGETARCH=aarch64; else TARGETARCH=x86_64; fi \
  && curl -fsSL https://github.com/grpc/grpc-web/releases/download/1.4.2/protoc-gen-grpc-web-1.4.2-linux-${TARGETARCH} -o /tmp/protoc-gen-grpc-web
 
-FROM debian:bullseye-20221024-slim
+FROM gcr.io/distroless/static-debian11
 COPY --from=build --link --chmod=0755 --chown=root:root /tmp/protoc-gen-grpc-web .
 USER nobody
 ENTRYPOINT [ "/protoc-gen-grpc-web" ]

--- a/plugins/protocolbuffers/cpp/v21.7/Dockerfile
+++ b/plugins/protocolbuffers/cpp/v21.7/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114 AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch v21
 WORKDIR /build/protobuf/
 RUN bazel build '//:protoc_lib'
 COPY --link BUILD cpp.cc plugins/
-RUN bazel build '//plugins:protoc-gen-cpp'
+RUN bazel build '//plugins:protoc-gen-cpp.stripped'
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-cpp .
 USER nobody
 ENTRYPOINT ["/protoc-gen-cpp"]

--- a/plugins/protocolbuffers/cpp/v21.8/Dockerfile
+++ b/plugins/protocolbuffers/cpp/v21.8/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114 AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch v21
 WORKDIR /build/protobuf/
 RUN bazel build '//:protoc_lib'
 COPY --link BUILD cpp.cc plugins/
-RUN bazel build '//plugins:protoc-gen-cpp'
+RUN bazel build '//plugins:protoc-gen-cpp.stripped'
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-cpp .
 USER nobody
 ENTRYPOINT ["/protoc-gen-cpp"]

--- a/plugins/protocolbuffers/cpp/v21.9/Dockerfile
+++ b/plugins/protocolbuffers/cpp/v21.9/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114 AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch v21
 WORKDIR /build/protobuf/
 RUN bazel build '//:protoc_lib'
 COPY --link BUILD cpp.cc plugins/
-RUN bazel build '//plugins:protoc-gen-cpp'
+RUN bazel build '//plugins:protoc-gen-cpp.stripped'
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-cpp .
 USER nobody
 ENTRYPOINT ["/protoc-gen-cpp"]

--- a/plugins/protocolbuffers/csharp/v21.7/Dockerfile
+++ b/plugins/protocolbuffers/csharp/v21.7/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114 AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch v21
 WORKDIR /build/protobuf/
 RUN bazel build '//:protoc_lib'
 COPY --link BUILD csharp.cc plugins/
-RUN bazel build '//plugins:protoc-gen-csharp'
+RUN bazel build '//plugins:protoc-gen-csharp.stripped'
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-csharp .
 USER nobody
 ENTRYPOINT ["/protoc-gen-csharp"]

--- a/plugins/protocolbuffers/csharp/v21.8/Dockerfile
+++ b/plugins/protocolbuffers/csharp/v21.8/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114 AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch v21
 WORKDIR /build/protobuf/
 RUN bazel build '//:protoc_lib'
 COPY --link BUILD csharp.cc plugins/
-RUN bazel build '//plugins:protoc-gen-csharp'
+RUN bazel build '//plugins:protoc-gen-csharp.stripped'
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-csharp .
 USER nobody
 ENTRYPOINT ["/protoc-gen-csharp"]

--- a/plugins/protocolbuffers/csharp/v21.9/Dockerfile
+++ b/plugins/protocolbuffers/csharp/v21.9/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114 AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch v21
 WORKDIR /build/protobuf/
 RUN bazel build '//:protoc_lib'
 COPY --link BUILD csharp.cc plugins/
-RUN bazel build '//plugins:protoc-gen-csharp'
+RUN bazel build '//plugins:protoc-gen-csharp.stripped'
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-csharp .
 USER nobody
 ENTRYPOINT ["/protoc-gen-csharp"]

--- a/plugins/protocolbuffers/java/v21.7/Dockerfile
+++ b/plugins/protocolbuffers/java/v21.7/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114 AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch v21
 WORKDIR /build/protobuf/
 RUN bazel build '//:protoc_lib'
 COPY --link BUILD java.cc plugins/
-RUN bazel build '//plugins:protoc-gen-java'
+RUN bazel build '//plugins:protoc-gen-java.stripped'
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-java .
 USER nobody
 ENTRYPOINT ["/protoc-gen-java"]

--- a/plugins/protocolbuffers/java/v21.8/Dockerfile
+++ b/plugins/protocolbuffers/java/v21.8/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114 AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch v21
 WORKDIR /build/protobuf/
 RUN bazel build '//:protoc_lib'
 COPY --link BUILD java.cc plugins/
-RUN bazel build '//plugins:protoc-gen-java'
+RUN bazel build '//plugins:protoc-gen-java.stripped'
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-java .
 USER nobody
 ENTRYPOINT ["/protoc-gen-java"]

--- a/plugins/protocolbuffers/java/v21.9/Dockerfile
+++ b/plugins/protocolbuffers/java/v21.9/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114 AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch v21
 WORKDIR /build/protobuf/
 RUN bazel build '//:protoc_lib'
 COPY --link BUILD java.cc plugins/
-RUN bazel build '//plugins:protoc-gen-java'
+RUN bazel build '//plugins:protoc-gen-java.stripped'
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-java .
 USER nobody
 ENTRYPOINT ["/protoc-gen-java"]

--- a/plugins/protocolbuffers/js/v3.21.2/Dockerfile
+++ b/plugins/protocolbuffers/js/v3.21.2/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221024-slim AS build
+FROM debian:bullseye-20221114 AS build
 
 ARG TARGETARCH
 
@@ -12,7 +12,7 @@ RUN arch=${TARGETARCH}; \
  && tar zxf protobuf-javascript.tar.gz bin/protoc-gen-js \
  && rm -f protobuf-javascript.tar.gz
 
-FROM debian:bullseye-20221024-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /tmp/bin/protoc-gen-js .
 USER nobody
 ENTRYPOINT ["/protoc-gen-js"]

--- a/plugins/protocolbuffers/kotlin/v21.7/Dockerfile
+++ b/plugins/protocolbuffers/kotlin/v21.7/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114 AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch v21
 WORKDIR /build/protobuf/
 RUN bazel build '//:protoc_lib'
 COPY --link BUILD kotlin.cc plugins/
-RUN bazel build '//plugins:protoc-gen-kotlin'
+RUN bazel build '//plugins:protoc-gen-kotlin.stripped'
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-kotlin .
 USER nobody
 ENTRYPOINT ["/protoc-gen-kotlin"]

--- a/plugins/protocolbuffers/kotlin/v21.8/Dockerfile
+++ b/plugins/protocolbuffers/kotlin/v21.8/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114 AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch v21
 WORKDIR /build/protobuf/
 RUN bazel build '//:protoc_lib'
 COPY --link BUILD kotlin.cc plugins/
-RUN bazel build '//plugins:protoc-gen-kotlin'
+RUN bazel build '//plugins:protoc-gen-kotlin.stripped'
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-kotlin .
 USER nobody
 ENTRYPOINT ["/protoc-gen-kotlin"]

--- a/plugins/protocolbuffers/kotlin/v21.9/Dockerfile
+++ b/plugins/protocolbuffers/kotlin/v21.9/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114-slim AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch v21
 WORKDIR /build/protobuf/
 RUN bazel build '//:protoc_lib'
 COPY --link BUILD kotlin.cc plugins/
-RUN bazel build '//plugins:protoc-gen-kotlin'
+RUN bazel build '//plugins:protoc-gen-kotlin.stripped'
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-kotlin .
 USER nobody
 ENTRYPOINT ["/protoc-gen-kotlin"]

--- a/plugins/protocolbuffers/objc/v21.7/Dockerfile
+++ b/plugins/protocolbuffers/objc/v21.7/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114-slim AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch v21
 WORKDIR /build/protobuf/
 RUN bazel build '//:protoc_lib'
 COPY --link BUILD objectivec.cc plugins/
-RUN bazel build '//plugins:protoc-gen-objectivec'
+RUN bazel build '//plugins:protoc-gen-objectivec.stripped'
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-objectivec .
 USER nobody
 ENTRYPOINT ["/protoc-gen-objectivec"]

--- a/plugins/protocolbuffers/objc/v21.8/Dockerfile
+++ b/plugins/protocolbuffers/objc/v21.8/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114-slim AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch v21
 WORKDIR /build/protobuf/
 RUN bazel build '//:protoc_lib'
 COPY --link BUILD objectivec.cc plugins/
-RUN bazel build '//plugins:protoc-gen-objectivec'
+RUN bazel build '//plugins:protoc-gen-objectivec.stripped'
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-objectivec .
 USER nobody
 ENTRYPOINT ["/protoc-gen-objectivec"]

--- a/plugins/protocolbuffers/objc/v21.9/Dockerfile
+++ b/plugins/protocolbuffers/objc/v21.9/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114-slim AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch v21
 WORKDIR /build/protobuf/
 RUN bazel build '//:protoc_lib'
 COPY --link BUILD objectivec.cc plugins/
-RUN bazel build '//plugins:protoc-gen-objectivec'
+RUN bazel build '//plugins:protoc-gen-objectivec.stripped'
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-objectivec .
 USER nobody
 ENTRYPOINT ["/protoc-gen-objectivec"]

--- a/plugins/protocolbuffers/php/v21.7/Dockerfile
+++ b/plugins/protocolbuffers/php/v21.7/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114-slim AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch v21
 WORKDIR /build/protobuf/
 RUN bazel build '//:protoc_lib'
 COPY --link BUILD php.cc plugins/
-RUN bazel build '//plugins:protoc-gen-php'
+RUN bazel build '//plugins:protoc-gen-php.stripped'
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-php .
 USER nobody
 ENTRYPOINT ["/protoc-gen-php"]

--- a/plugins/protocolbuffers/php/v21.8/Dockerfile
+++ b/plugins/protocolbuffers/php/v21.8/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114-slim AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch v21
 WORKDIR /build/protobuf/
 RUN bazel build '//:protoc_lib'
 COPY --link BUILD php.cc plugins/
-RUN bazel build '//plugins:protoc-gen-php'
+RUN bazel build '//plugins:protoc-gen-php.stripped'
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-php .
 USER nobody
 ENTRYPOINT ["/protoc-gen-php"]

--- a/plugins/protocolbuffers/php/v21.9/Dockerfile
+++ b/plugins/protocolbuffers/php/v21.9/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114-slim AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch v21
 WORKDIR /build/protobuf/
 RUN bazel build '//:protoc_lib'
 COPY --link BUILD php.cc plugins/
-RUN bazel build '//plugins:protoc-gen-php'
+RUN bazel build '//plugins:protoc-gen-php.stripped'
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-php .
 USER nobody
 ENTRYPOINT ["/protoc-gen-php"]

--- a/plugins/protocolbuffers/pyi/v21.7/Dockerfile
+++ b/plugins/protocolbuffers/pyi/v21.7/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221024 AS build
+FROM debian:bullseye-20221114-slim AS build
 
 ARG TARGETARCH
 
@@ -33,9 +33,9 @@ cc_binary(
     ],
 )
 EOF
-RUN bazel build '//plugins/pyi:protoc-gen-pyi'
+RUN bazel build '//plugins/pyi:protoc-gen-pyi.stripped'
 
-FROM debian:bullseye-20221024-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/pyi/protoc-gen-pyi .
 USER nobody
 ENTRYPOINT ["/protoc-gen-pyi"]

--- a/plugins/protocolbuffers/pyi/v21.8/Dockerfile
+++ b/plugins/protocolbuffers/pyi/v21.8/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221024 AS build
+FROM debian:bullseye-20221114-slim AS build
 
 ARG TARGETARCH
 
@@ -33,9 +33,9 @@ cc_binary(
     ],
 )
 EOF
-RUN bazel build '//plugins/pyi:protoc-gen-pyi'
+RUN bazel build '//plugins/pyi:protoc-gen-pyi.stripped'
 
-FROM debian:bullseye-20221024-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/pyi/protoc-gen-pyi .
 USER nobody
 ENTRYPOINT ["/protoc-gen-pyi"]

--- a/plugins/protocolbuffers/pyi/v21.9/Dockerfile
+++ b/plugins/protocolbuffers/pyi/v21.9/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221024 AS build
+FROM debian:bullseye-20221114-slim AS build
 
 ARG TARGETARCH
 
@@ -33,9 +33,9 @@ cc_binary(
     ],
 )
 EOF
-RUN bazel build '//plugins/pyi:protoc-gen-pyi'
+RUN bazel build '//plugins/pyi:protoc-gen-pyi.stripped'
 
-FROM debian:bullseye-20221024-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/pyi/protoc-gen-pyi .
 USER nobody
 ENTRYPOINT ["/protoc-gen-pyi"]

--- a/plugins/protocolbuffers/python/v21.7/Dockerfile
+++ b/plugins/protocolbuffers/python/v21.7/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114-slim AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch v21
 WORKDIR /build/protobuf/
 RUN bazel build '//:protoc_lib'
 COPY --link BUILD python.cc plugins/
-RUN bazel build '//plugins:protoc-gen-python'
+RUN bazel build '//plugins:protoc-gen-python.stripped'
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-python .
 USER nobody
 ENTRYPOINT ["/protoc-gen-python"]

--- a/plugins/protocolbuffers/python/v21.8/Dockerfile
+++ b/plugins/protocolbuffers/python/v21.8/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114-slim AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch v21
 WORKDIR /build/protobuf/
 RUN bazel build '//:protoc_lib'
 COPY --link BUILD python.cc plugins/
-RUN bazel build '//plugins:protoc-gen-python'
+RUN bazel build '//plugins:protoc-gen-python.stripped'
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-python .
 USER nobody
 ENTRYPOINT ["/protoc-gen-python"]

--- a/plugins/protocolbuffers/python/v21.9/Dockerfile
+++ b/plugins/protocolbuffers/python/v21.9/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114-slim AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch v21
 WORKDIR /build/protobuf/
 RUN bazel build '//:protoc_lib'
 COPY --link BUILD python.cc plugins/
-RUN bazel build '//plugins:protoc-gen-python'
+RUN bazel build '//plugins:protoc-gen-python.stripped'
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-python .
 USER nobody
 ENTRYPOINT ["/protoc-gen-python"]

--- a/plugins/protocolbuffers/ruby/v21.7/Dockerfile
+++ b/plugins/protocolbuffers/ruby/v21.7/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114-slim AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch v21
 WORKDIR /build/protobuf/
 RUN bazel build '//:protoc_lib'
 COPY --link BUILD ruby.cc plugins/
-RUN bazel build '//plugins:protoc-gen-ruby'
+RUN bazel build '//plugins:protoc-gen-ruby.stripped'
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-ruby .
 USER nobody
 ENTRYPOINT ["/protoc-gen-ruby"]

--- a/plugins/protocolbuffers/ruby/v21.8/Dockerfile
+++ b/plugins/protocolbuffers/ruby/v21.8/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114-slim AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch v21
 WORKDIR /build/protobuf/
 RUN bazel build '//:protoc_lib'
 COPY --link BUILD ruby.cc plugins/
-RUN bazel build '//plugins:protoc-gen-ruby'
+RUN bazel build '//plugins:protoc-gen-ruby.stripped'
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-ruby .
 USER nobody
 ENTRYPOINT ["/protoc-gen-ruby"]

--- a/plugins/protocolbuffers/ruby/v21.9/Dockerfile
+++ b/plugins/protocolbuffers/ruby/v21.9/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM debian:bullseye-20221004 AS build
+FROM debian:bullseye-20221114-slim AS build
 
 ARG TARGETARCH
 
@@ -15,9 +15,9 @@ RUN git clone https://github.com/protocolbuffers/protobuf --depth 1 --branch v21
 WORKDIR /build/protobuf/
 RUN bazel build '//:protoc_lib'
 COPY --link BUILD ruby.cc plugins/
-RUN bazel build '//plugins:protoc-gen-ruby'
+RUN bazel build '//plugins:protoc-gen-ruby.stripped'
 
-FROM debian:bullseye-20221004-slim
+FROM gcr.io/distroless/cc-debian11
 COPY --from=build --link --chmod=0755 /build/protobuf/bazel-bin/plugins/protoc-gen-ruby .
 USER nobody
 ENTRYPOINT ["/protoc-gen-ruby"]


### PR DESCRIPTION
As a prereq to packaging plugins for installation, we should switch to smaller base images. This will also improve security by not including a full OS in our plugins.

Overall savings varies by plugins with Java and Node plugins being the largest. In the best case, we see ~93% size reduction in some images.