### PR TITLE
create Go CLI to automate plugin releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Login to GitHub Container Registry
+      if: github.repository == 'bufbuild/plugins'
       uses: docker/login-action@v2
       with:
         registry: ghcr.io
@@ -78,6 +79,7 @@ jobs:
       shell: bash
       run: make test DOCKER_ORG="ghcr.io/bufbuild"
     - name: Push
+      if: github.repository == 'bufbuild/plugins'
       shell: bash
       env:
         ALL_MODIFIED_FILES: ${{ steps.changed-files.outputs.all_modified_files }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,6 @@ concurrency:
 jobs:
   pr:
     env:
-      dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
       BUILDKIT_PROGRESS: plain
     runs-on: ubuntu-latest
     steps:
@@ -56,8 +55,8 @@ jobs:
       with:
         driver: docker
         driver-opts: network=host
-    - if: ${{ env.dockerhub_username != '' }}
-      name: Login to Docker Hub
+    - name: Login to Docker Hub
+      if: github.repository == 'bufbuild/plugins'
       uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/push_all.yml
+++ b/.github/workflows/push_all.yml
@@ -10,6 +10,7 @@ concurrency: ci-${{ github.ref }}
 
 jobs:
   push_all:
+    if: github.repository == 'bufbuild/plugins'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Fetch latest versions
+name: Create Release
 
 on:
   schedule:
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  fetch-versions:
+  release:
     if: github.repository == 'bufbuild/plugins'
     runs-on: ubuntu-22.04
     steps:
@@ -18,7 +18,7 @@ jobs:
           private_key: ${{ secrets.TOKEN_EXCHANGE_GH_APP_PRIVATE_KEY }}
           repository: ${{ github.repository }}
           permissions: >-
-            {"contents": "write", "pull_requests": "write"}
+            {"contents": "write"}
       - name: Checkout repository code
         uses: actions/checkout@v3
         with:
@@ -29,22 +29,15 @@ jobs:
           go-version: 1.19.x
           check-latest: true
           cache: true
-      - name: Install buf cli
-        run: |
-          go install github.com/bufbuild/buf/cmd/buf@main
-      - name: Fetch all versions
+      - name: Create Release
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          MINISIGN_PRIVATE_KEY: ${{ secrets.MINISIGN_PRIVATE_KEY }}
+          MINISIGN_PRIVATE_KEY_PASSWORD: ${{ secrets.MINISIGN_PRIVATE_KEY_PASSWORD }}
         run: |
-          go run ./cmd/fetcher .
-      - name: Create PR
-        uses: peter-evans/create-pull-request@b4d51739f96fca8047ad065eccef63442d8e99f7
-        with:
-          add-paths: .
-          commit-message: "detected new plugin versions"
-          branch: fetch-versions
-          delete-branch: true
-          title: "Found new plugin versions"
-          body: "New plugin versions found. Please review."
-          assignees: mfridman, pkwarren
-          token: ${{ steps.generate_token.outputs.token }}
+          echo "${MINISIGN_PRIVATE_KEY}" > minisign.key
+          go run ./cmd/release -minisign-private-key minisign.key .
+      - name: Clean Up
+        if: always()
+        run: |
+          rm -fv minisign.key

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .build/
 .idea/
 .vscode/
+minisign.*
 node_modules/
 tests/testdata/**/buf.gen.yaml
 tests/testdata/**/gen/

--- a/cmd/dependency-order/main.go
+++ b/cmd/dependency-order/main.go
@@ -19,8 +19,9 @@ func main() {
 	basedir := flag.Args()[0]
 
 	plugins := make([]*plugin.Plugin, 0)
-	if err := plugin.Walk(basedir, func(plugin *plugin.Plugin) {
+	if err := plugin.Walk(basedir, func(plugin *plugin.Plugin) error {
 		plugins = append(plugins, plugin)
+		return nil
 	}); err != nil {
 		log.Fatalf("failed to walk directory: %v", err)
 	}

--- a/cmd/fetcher/main.go
+++ b/cmd/fetcher/main.go
@@ -26,12 +26,6 @@ func main() {
 		os.Exit(2)
 	}
 	root := os.Args[1]
-	depth := strings.Count(root, string(os.PathSeparator))
-	if depth > 1 {
-		_, _ = fmt.Fprintf(os.Stderr, "usage: %s <directory>\n", os.Args)
-		os.Exit(2)
-	}
-	depth = 1 - depth
 	created, err := run(context.Background(), root)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "failed to fetch versions: %v\n", err)

--- a/cmd/release/main.go
+++ b/cmd/release/main.go
@@ -1,0 +1,583 @@
+package main
+
+import (
+	"archive/zip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"aead.dev/minisign"
+	"github.com/bufbuild/buf/private/bufpkg/bufplugin/bufpluginref"
+	"github.com/bufbuild/plugins/internal/plugin"
+	"github.com/google/go-github/v48/github"
+	"github.com/hashicorp/go-retryablehttp"
+	"golang.org/x/mod/semver"
+	"golang.org/x/oauth2"
+)
+
+const (
+	githubOwner = "bufbuild"
+	// This is separate from githubOwner for testing releases (can point at personal fork)
+	githubReleaseOwner   = githubOwner // "pkwarren"
+	githubRepo           = "plugins"
+	packageTypeContainer = "container"
+	pluginReleasesFile   = "plugin-releases.json"
+)
+
+type ReleaseStatus int
+
+const (
+	EXISTING ReleaseStatus = iota
+	NEW
+	UPDATED
+)
+
+type PluginReleases struct {
+	Releases []PluginRelease `json:"releases"`
+}
+
+type PluginRelease struct {
+	PluginName       string        `json:"name"`              // org/name for the plugin (without remote)
+	PluginVersion    string        `json:"version"`           // version of the plugin (including 'v' prefix)
+	PluginZipDigest  string        `json:"zip_digest"`        // <digest-type>:<digest> for plugin .zip download
+	PluginYAMLDigest string        `json:"yaml_digest"`       // <digest-type>:<digest> for buf.plugin.yaml
+	GHCRImageDigest  string        `json:"ghcr_image_digest"` // <digest-type>:<digest> for ghcr.io/bufbuild/plugins-<org>-<name>:v<version> image
+	ReleaseTag       string        `json:"release_tag"`       // GitHub release tag - i.e. 20221121.1
+	URL              string        `json:"url"`               // URL to GitHub release zip file for the plugin - i.e. https://github.com/bufbuild/plugins/releases/download/20221121.1/bufbuild-connect-go-v1.1.0.zip
+	LastUpdated      time.Time     `json:"last_updated"`
+	Status           ReleaseStatus `json:"-"`
+}
+
+type pluginNameVersion struct {
+	name, version string
+}
+
+func main() {
+	var (
+		minisignPrivateKey string
+		dryRun             bool
+	)
+	flag.BoolVar(&dryRun, "dry-run", false, "perform a dry-run (no GitHub modifications)")
+	flag.StringVar(&minisignPrivateKey, "minisign-private-key", "", "path to minisign private key file")
+	flag.Parse()
+
+	if len(flag.Args()) != 1 {
+		_, _ = fmt.Fprintf(os.Stderr, "usage: %s [-dry-run] [-minisign-private-key <file>] <directory>\n", os.Args)
+		os.Exit(2)
+	}
+	root := flag.Args()[0]
+	if err := run(root, minisignPrivateKey, dryRun); err != nil {
+		log.Fatalln(err.Error())
+	}
+}
+
+func run(root string, minisignPrivateKey string, dryRun bool) error {
+	// Create temporary directory
+	tmpDir, err := os.MkdirTemp("", "plugins-release")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary directory: %w", err)
+	}
+	log.Printf("created tmp dir: %s", tmpDir)
+	if !dryRun {
+		defer func() {
+			if err := os.RemoveAll(tmpDir); err != nil {
+				log.Printf("failed to remove %q: %v", tmpDir, err)
+			}
+		}()
+	}
+
+	ctx := context.Background()
+	client := newGitHubClient()
+	latestRelease, err := getLatestRelease(ctx, client)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve latest release: %w", err)
+	}
+
+	releases, err := loadPluginReleases(ctx, client, latestRelease)
+	if err != nil {
+		return fmt.Errorf("failed to determine latest plugin releases: %w", err)
+	}
+	if releases == nil {
+		log.Printf("no current release found")
+		releases = &PluginReleases{}
+	}
+
+	pluginNameVersionToRelease := make(map[pluginNameVersion]PluginRelease, len(releases.Releases))
+	for _, release := range releases.Releases {
+		key := pluginNameVersion{name: release.PluginName, version: release.PluginVersion}
+		if _, ok := pluginNameVersionToRelease[key]; ok {
+			return fmt.Errorf("duplicate plugin discovered in releases file: %+v", key)
+		}
+		pluginNameVersionToRelease[key] = release
+	}
+
+	var newPlugins []PluginRelease
+	var existingPlugins []PluginRelease
+	now := time.Now().UTC().Truncate(time.Second)
+	releaseName, err := calculateNextRelease(now, latestRelease)
+	if err != nil {
+		return fmt.Errorf("failed to determine next release name: %w", err)
+	}
+
+	n := 0
+	if err := plugin.Walk(root, func(plugin *plugin.Plugin) error {
+		n++
+		if n > 2 {
+			return nil
+		}
+		identity, err := bufpluginref.PluginIdentityForString(plugin.Name)
+		if err != nil {
+			return nil
+		}
+		pluginYamlDigest, err := calculateDigest(plugin.Path)
+		if err != nil {
+			return err
+		}
+		imageName, imageDigest, err := fetchGHCRImageNameAndDigest(context.Background(), client, plugin)
+		if err != nil {
+			return err
+		}
+		key := pluginNameVersion{name: identity.Owner() + "/" + identity.Plugin(), version: plugin.PluginVersion}
+		release := pluginNameVersionToRelease[key]
+		// Found existing release - only rebuild if changed image digest or buf.plugin.yaml digest
+		if release.GHCRImageDigest != imageDigest || release.PluginYAMLDigest != pluginYamlDigest {
+			downloadURL, err := pluginDownloadURL(plugin, releaseName)
+			if err != nil {
+				return err
+			}
+			zipDigest, err := createPluginZip(tmpDir, plugin, imageName, imageDigest)
+			if err != nil {
+				return err
+			}
+			status := UPDATED
+			if release.GHCRImageDigest == "" {
+				status = NEW
+			}
+			newPlugins = append(newPlugins, PluginRelease{
+				PluginName:       fmt.Sprintf("%s/%s", identity.Owner(), identity.Plugin()),
+				PluginVersion:    plugin.PluginVersion,
+				PluginZipDigest:  zipDigest,
+				PluginYAMLDigest: pluginYamlDigest,
+				GHCRImageDigest:  imageDigest,
+				ReleaseTag:       releaseName,
+				URL:              downloadURL,
+				LastUpdated:      now,
+				Status:           status,
+			})
+		} else {
+			log.Printf("plugin %s:%s unchanged", release.PluginName, release.PluginVersion)
+			release.Status = EXISTING
+			existingPlugins = append(existingPlugins, release)
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to discover plugins in path %q: %w", root, err)
+	}
+
+	if len(newPlugins) == 0 {
+		log.Printf("no changes to plugins since %v", latestRelease.GetTagName())
+		return nil
+	}
+
+	plugins := make([]PluginRelease, 0, len(newPlugins)+len(existingPlugins))
+	plugins = append(plugins, newPlugins...)
+	plugins = append(plugins, existingPlugins...)
+	sort.Slice(plugins, func(i, j int) bool {
+		p1, p2 := plugins[i], plugins[j]
+		if p1.PluginName != p2.PluginName {
+			return p1.PluginName < p2.PluginName
+		}
+		return semver.Compare(p1.PluginVersion, p2.PluginVersion) < 0
+	})
+	if err := createPluginReleases(tmpDir, plugins); err != nil {
+		return fmt.Errorf("failed to create %s: %w", pluginReleasesFile, err)
+	}
+
+	minisignPrivateKeyPassword := os.Getenv("MINISIGN_PRIVATE_KEY_PASSWORD")
+	if minisignPrivateKey != "" && minisignPrivateKeyPassword != "" {
+		if err := signPluginReleases(tmpDir, minisignPrivateKey, minisignPrivateKeyPassword); err != nil {
+			return fmt.Errorf("failed to sign %q: %w", filepath.Join(tmpDir, pluginReleasesFile), err)
+		}
+	} else {
+		log.Printf("skipping signing of %s", pluginReleasesFile)
+	}
+
+	if dryRun {
+		log.Printf("skipping GitHub release creation in dry-run mode")
+		log.Printf("release assets created in %q", tmpDir)
+		return nil
+	}
+	if err := createRelease(ctx, client, releaseName, plugins, tmpDir); err != nil {
+		return fmt.Errorf("failed to create GitHub release: %w", err)
+	}
+	return nil
+}
+
+func createRelease(ctx context.Context, client *github.Client, releaseName string, plugins []PluginRelease, tmpDir string) error {
+	// Create GitHub release
+	release, _, err := client.Repositories.CreateRelease(ctx, githubReleaseOwner, githubRepo, &github.RepositoryRelease{
+		Name:    github.String(releaseName),
+		TagName: github.String("releases/" + releaseName),
+		Body:    github.String(createReleaseBody(releaseName, plugins)),
+	})
+	if err != nil {
+		return err
+	}
+	return filepath.WalkDir(tmpDir, func(path string, d fs.DirEntry, err error) error {
+		if d.IsDir() {
+			return nil
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		log.Printf("uploading: %s", d.Name())
+		_, _, err = client.Repositories.UploadReleaseAsset(ctx, githubReleaseOwner, githubRepo, release.GetID(), &github.UploadOptions{
+			Name: d.Name(),
+		}, f)
+		return err
+	})
+}
+
+func createReleaseBody(name string, plugins []PluginRelease) string {
+	var sb strings.Builder
+	pluginsByStatus := make(map[ReleaseStatus][]PluginRelease)
+	for _, p := range plugins {
+		pluginsByStatus[p.Status] = append(pluginsByStatus[p.Status], p)
+	}
+
+	sb.WriteString(fmt.Sprintf("# Buf Remote Plugins Release %s\n\n", name))
+
+	if newPlugins := pluginsByStatus[NEW]; len(newPlugins) > 0 {
+		sb.WriteString(`## New Plugins
+
+| Plugin | Version | Link |
+|--------|---------|------|
+`)
+		for _, p := range newPlugins {
+			sb.WriteString(fmt.Sprintf("| %s | %s | [Download](%s) |\n", p.PluginName, p.PluginVersion, p.URL))
+		}
+		sb.WriteString("\n")
+	}
+
+	if updatedPlugins := pluginsByStatus[UPDATED]; len(updatedPlugins) > 0 {
+		sb.WriteString(`## Updated Plugins
+
+| Plugin | Version | Link |
+|--------|---------|------|
+`)
+		for _, p := range updatedPlugins {
+			sb.WriteString(fmt.Sprintf("| %s | %s | [Download](%s) |\n", p.PluginName, p.PluginVersion, p.URL))
+		}
+		sb.WriteString("\n")
+	}
+
+	if existingPlugins := pluginsByStatus[EXISTING]; len(existingPlugins) > 0 {
+		sb.WriteString(`## Previously Released Plugins
+
+| Plugin | Version | Release | Link |
+|--------|---------|---------|------|
+`)
+		for _, p := range existingPlugins {
+			sb.WriteString(fmt.Sprintf("| %s | %s | %s | [Download](%s) |\n", p.PluginName, p.PluginVersion, p.ReleaseTag, p.URL))
+		}
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
+func signPluginReleases(dir string, keyPath string, password string) error {
+	releasesFile := filepath.Join(dir, pluginReleasesFile)
+	log.Printf("signing: %s", releasesFile)
+	privateKey, err := minisign.PrivateKeyFromFile(password, keyPath)
+	if err != nil {
+		return err
+	}
+	releasesFileBytes, err := os.ReadFile(releasesFile)
+	if err != nil {
+		return err
+	}
+	signature := minisign.Sign(privateKey, releasesFileBytes)
+	return os.WriteFile(releasesFile+".minisig", signature, 0644)
+}
+
+func createPluginZip(basedir string, plugin *plugin.Plugin, imageName string, imageDigest string) (string, error) {
+	if err := pullImage(imageName, imageDigest); err != nil {
+		return "", err
+	}
+	zipName, err := pluginZipName(plugin)
+	if err != nil {
+		return "", err
+	}
+	pluginTempDir, err := os.MkdirTemp(basedir, strings.TrimSuffix(zipName, filepath.Ext(zipName)))
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if err := os.RemoveAll(pluginTempDir); err != nil {
+			log.Printf("failed to remove %q: %v", pluginTempDir, err)
+		}
+	}()
+	if err := saveImageToDir(fmt.Sprintf("%s@%s", imageName, imageDigest), pluginTempDir); err != nil {
+		return "", err
+	}
+	zipFile := filepath.Join(basedir, zipName)
+	zf, err := os.OpenFile(zipFile, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0644)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if err := zf.Close(); !errors.Is(err, os.ErrClosed) {
+			log.Printf("failed to close: %v", err)
+		}
+	}()
+	zw := zip.NewWriter(zf)
+	if err := addFileToZip(zw, plugin.Path); err != nil {
+		return "", err
+	}
+	if err := addFileToZip(zw, filepath.Join(pluginTempDir, "image.tar")); err != nil {
+		return "", err
+	}
+	if err := zw.Close(); err != nil {
+		return "", err
+	}
+	if err := zf.Close(); err != nil {
+		return "", err
+	}
+	digest, err := calculateDigest(zipFile)
+	if err != nil {
+		return "", err
+	}
+	return digest, nil
+}
+
+func addFileToZip(zipWriter *zip.Writer, path string) error {
+	w, err := zipWriter.Create(filepath.Base(path))
+	if err != nil {
+		return err
+	}
+	r, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := r.Close(); err != nil {
+			log.Printf("failed to close: %v", err)
+		}
+	}()
+	if _, err := io.Copy(w, r); err != nil {
+		return err
+	}
+	return nil
+}
+
+func saveImageToDir(imageRef string, dir string) error {
+	dockerCmd, err := exec.LookPath("docker")
+	if err != nil {
+		return err
+	}
+	dockerSave := exec.Cmd{
+		Path: dockerCmd,
+		Args: []string{
+			dockerCmd,
+			"save",
+			imageRef,
+			"-o",
+			"image.tar",
+		},
+		Dir:    dir,
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
+	return dockerSave.Run()
+}
+
+func createPluginReleases(dir string, plugins []PluginRelease) error {
+	f, err := os.OpenFile(filepath.Join(dir, pluginReleasesFile), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			log.Printf("failed to close: %v", err)
+		}
+	}()
+	encoder := json.NewEncoder(f)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(&PluginReleases{Releases: plugins})
+}
+
+func pullImage(name string, digest string) error {
+	dockerPath, err := exec.LookPath("docker")
+	if err != nil {
+		return err
+	}
+	image := fmt.Sprintf("%s@%s", name, digest)
+	log.Printf("pulling image: %s", image)
+	pullCmd := exec.Cmd{
+		Path: dockerPath,
+		Args: []string{
+			dockerPath,
+			"pull",
+			image,
+		},
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
+	return pullCmd.Run()
+}
+
+func calculateNextRelease(now time.Time, latestRelease *github.RepositoryRelease) (string, error) {
+	var releaseName string
+	var latestReleaseName string
+	if latestRelease != nil {
+		latestReleaseName = strings.TrimPrefix(latestRelease.GetTagName(), "releases/")
+	}
+	currentDate := now.UTC().Format("20060102")
+	if latestRelease == nil || !strings.HasPrefix(latestReleaseName, currentDate+".") {
+		releaseName = currentDate + ".1"
+	} else {
+		_, revision, ok := strings.Cut(latestReleaseName, ".")
+		if !ok {
+			return "", fmt.Errorf("malformed latest release tag name: %v", latestRelease.GetTagName())
+		}
+		currentRevision, err := strconv.Atoi(revision)
+		if err != nil {
+			return "", err
+		}
+		releaseName = currentDate + "." + strconv.Itoa(currentRevision+1)
+	}
+	return releaseName, nil
+}
+
+func pluginDownloadURL(plugin *plugin.Plugin, releaseName string) (string, error) {
+	zipName, err := pluginZipName(plugin)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("https://github.com/%s/%s/releases/download/%s/%s", githubReleaseOwner, githubRepo, releaseName, zipName), nil
+}
+
+func pluginZipName(plugin *plugin.Plugin) (string, error) {
+	identity, err := bufpluginref.PluginIdentityForString(plugin.Name)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s-%s-%s.zip", identity.Owner(), identity.Plugin(), plugin.PluginVersion), nil
+}
+
+func calculateDigest(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			log.Printf("failed to close: %v", err)
+		}
+	}()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, f); err != nil {
+		return "", err
+	}
+	hashBytes := hash.Sum(nil)
+	return "sha256:" + hex.EncodeToString(hashBytes), nil
+}
+
+func fetchGHCRImageNameAndDigest(ctx context.Context, client *github.Client, plugin *plugin.Plugin) (string, string, error) {
+	identity, err := bufpluginref.PluginIdentityForString(plugin.Name)
+	if err != nil {
+		return "", "", err
+	}
+	packageName := fmt.Sprintf("plugins-%s-%s", identity.Owner(), identity.Plugin())
+	versions, _, err := client.Organizations.PackageGetAllVersions(ctx, githubOwner, packageTypeContainer, packageName, &github.PackageListOptions{})
+	if err != nil {
+		return "", "", err
+	}
+	for _, version := range versions {
+		if version.GetMetadata() == nil || version.GetMetadata().GetContainer() == nil {
+			continue
+		}
+		for _, tag := range version.GetMetadata().GetContainer().Tags {
+			if tag == plugin.PluginVersion {
+				imageName := fmt.Sprintf("ghcr.io/%s/%s", githubOwner, packageName)
+				return imageName, version.GetName(), nil
+			}
+		}
+	}
+	return "", "", fmt.Errorf("no digest found for: %v:%v", identity.IdentityString(), plugin.PluginVersion)
+}
+
+func getLatestRelease(ctx context.Context, client *github.Client) (*github.RepositoryRelease, error) {
+	release, resp, err := client.Repositories.GetLatestRelease(ctx, githubReleaseOwner, githubRepo)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			// no latest release
+			return nil, nil
+		}
+		return nil, err
+	}
+	return release, nil
+}
+
+func loadPluginReleases(ctx context.Context, client *github.Client, latestRelease *github.RepositoryRelease) (*PluginReleases, error) {
+	if latestRelease == nil {
+		return nil, nil
+	}
+
+	var pluginVersionsAssetID int64
+	for _, asset := range latestRelease.Assets {
+		if asset.GetName() == pluginReleasesFile {
+			// Found asset
+			pluginVersionsAssetID = asset.GetID()
+			break
+		}
+	}
+	if pluginVersionsAssetID == 0 {
+		// no plugin-versions.json in latest release
+		return nil, nil
+	}
+	rc, _, err := client.Repositories.DownloadReleaseAsset(ctx, githubReleaseOwner, githubRepo, pluginVersionsAssetID, http.DefaultClient)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := rc.Close(); err != nil {
+			log.Printf("failed to close: %v", err)
+		}
+	}()
+	var releases PluginReleases
+	if err := json.NewDecoder(rc).Decode(&releases); err != nil {
+		return nil, err
+	}
+	return &releases, nil
+}
+
+func newGitHubClient() *github.Client {
+	var client *http.Client
+	if ghToken := os.Getenv("GITHUB_TOKEN"); ghToken != "" {
+		ctx := context.Background()
+		ts := oauth2.StaticTokenSource(
+			&oauth2.Token{AccessToken: ghToken},
+		)
+		client = oauth2.NewClient(ctx, ts)
+	} else {
+		client = retryablehttp.NewClient().StandardClient()
+	}
+	return github.NewClient(client)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,9 @@ module github.com/bufbuild/plugins
 go 1.19
 
 require (
+	aead.dev/minisign v0.2.0
 	github.com/bufbuild/buf v1.9.1-0.20221104204513-91ec6001a5f1
-	github.com/google/go-github/v45 v45.2.0
+	github.com/google/go-github/v48 v48.1.0
 	github.com/hashicorp/go-retryablehttp v0.7.1
 	github.com/sethvargo/go-envconfig v0.8.2
 	github.com/stretchr/testify v1.8.1
@@ -26,6 +27,7 @@ require (
 	go.uber.org/atomic v1.10.0 // indirect
 	golang.org/x/crypto v0.1.0 // indirect
 	golang.org/x/net v0.2.0 // indirect
+	golang.org/x/sys v0.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.2-0.20220831092852-f930b1dc76e8 // indirect
 	gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+aead.dev/minisign v0.2.0 h1:kAWrq/hBRu4AARY6AlciO83xhNnW9UaC8YipS2uhLPk=
+aead.dev/minisign v0.2.0/go.mod h1:zdq6LdSd9TbuSxchxwhpA9zEb9YXcVGoE8JakuiGaIQ=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/bufbuild/buf v1.9.1-0.20221104204513-91ec6001a5f1 h1:3EYDkOqU0QyoYNzWTE6B3oSmQ3r4F5vhKi/Nr9Dt5Sg=
@@ -39,8 +41,8 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/go-github/v45 v45.2.0 h1:5oRLszbrkvxDDqBCNj2hjDZMKmvexaZ1xw/FCD+K3FI=
-github.com/google/go-github/v45 v45.2.0/go.mod h1:FObaZJEDSTa/WGCzZ2Z3eoCDXWJKMenWWTrd8jrta28=
+github.com/google/go-github/v48 v48.1.0 h1:nqPqq+0oRY2AMR/SRskGrrP4nnewPB7e/m2+kbT/UvM=
+github.com/google/go-github/v48 v48.1.0/go.mod h1:dDlehKBDo850ZPvCTK0sEqTCVWcrGl2LcDiajkYi89Y=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -81,6 +83,7 @@ go.uber.org/multierr v1.8.0 h1:dg6GjLku4EH+249NNmoIciG9N/jURbDG+pFlTkhzIC8=
 go.uber.org/multierr v1.8.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.1.0 h1:MDRAIl0xIo9Io2xV565hzXHw3zVseKrJKodhohM5CjU=
 golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -107,7 +110,12 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210228012217-479acdf4ea46/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
+golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/internal/fetchclient/fetchclient.go
+++ b/internal/fetchclient/fetchclient.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 
 	"github.com/bufbuild/plugins/internal/source"
-	"github.com/google/go-github/v45/github"
+	"github.com/google/go-github/v48/github"
 	"github.com/hashicorp/go-retryablehttp"
 	"golang.org/x/mod/semver"
 	"golang.org/x/oauth2"

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -36,7 +36,7 @@ type Dependency struct {
 
 // Walk loads every buf.plugin.yaml found in the specified root directory and calls the callback function with each plugin.
 // The callback is called in dependency order (all plugin dependencies are printed before the plugin).
-func Walk(dir string, f func(plugin *Plugin)) error {
+func Walk(dir string, f func(plugin *Plugin) error) error {
 	dir, err := filepath.Abs(dir)
 	if err != nil {
 		return err
@@ -81,7 +81,9 @@ func Walk(dir string, f func(plugin *Plugin)) error {
 		return err
 	}
 	for _, p := range sorted {
-		f(p)
+		if err := f(p); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -13,8 +13,9 @@ import (
 func TestWalk(t *testing.T) {
 	t.Parallel()
 	var plugins []*Plugin
-	err := Walk("../..", func(plugin *Plugin) {
+	err := Walk("../..", func(plugin *Plugin) error {
 		plugins = append(plugins, plugin)
+		return nil
 	})
 	require.NoError(t, err)
 	assert.NotEmpty(t, plugins)
@@ -23,8 +24,9 @@ func TestWalk(t *testing.T) {
 func TestFilterByPluginsEnv(t *testing.T) {
 	t.Parallel()
 	var plugins []*Plugin
-	err := Walk("../..", func(plugin *Plugin) {
+	err := Walk("../..", func(plugin *Plugin) error {
 		plugins = append(plugins, plugin)
+		return nil
 	})
 	require.NoError(t, err)
 	assert.Empty(t, runFilterByPluginsEnv(t, plugins, "no-match"))
@@ -44,8 +46,9 @@ func TestFilterByPluginsEnv(t *testing.T) {
 func TestFilterByChangedFiles(t *testing.T) {
 	t.Parallel()
 	var plugins []*Plugin
-	err := Walk("../..", func(plugin *Plugin) {
+	err := Walk("../..", func(plugin *Plugin) error {
 		plugins = append(plugins, plugin)
+		return nil
 	})
 	require.NoError(t, err)
 	assert.Empty(t, runFilterByChangedFiles(t, plugins, nil, false))

--- a/tests/plugins_test.go
+++ b/tests/plugins_test.go
@@ -152,8 +152,9 @@ func createBufGenYaml(t *testing.T, basedir string, plugin *plugin.Plugin) error
 func loadAllPlugins(t *testing.T) []*plugin.Plugin {
 	t.Helper()
 	var plugins []*plugin.Plugin
-	if err := plugin.Walk("..", func(plugin *plugin.Plugin) {
+	if err := plugin.Walk("..", func(plugin *plugin.Plugin) error {
 		plugins = append(plugins, plugin)
+		return nil
 	}); err != nil {
 		t.Fatalf("failed to find plugins: %v", err)
 	}


### PR DESCRIPTION
Create a Go CLI (cmd/release/main.go) which automates the creation of plugin releases. A release consists of the following:

* plugin-releases.json - Contains metadata about all plugins (including name, version, digests).
* plugin-releases.json.minisign - Minisign signature of plugin-releases.json.
* <owner>-<name>-<version>.zip - One or more zip files containing a buf.plugin.yaml and image.tar (created with docker save).

The CLI is configured to run once daily. It detects any changes since the latest release and will upload only the added/changed plugins.

There are two supported options to the CLI:

* `-minisign-private-key <key>`: Path to minisign private key. If omitted, the plugin-releases.json file will not be signed.
* `-dry-run`: If true, the release will be created locally and saved to a temporary directory on disk, but no changes will be made to GitHub.