### PR TITLE
collapse previously released plugins

### DIFF
--- a/cmd/release/main.go
+++ b/cmd/release/main.go
@@ -300,6 +300,8 @@ func createReleaseBody(name string, plugins []PluginRelease, publicKey *minisign
 
 	if existingPlugins := pluginsByStatus[EXISTING]; len(existingPlugins) > 0 {
 		sb.WriteString(`## Previously Released Plugins
+<details>
+    <summary>Expand</summary>
 
 | Plugin | Version | Release | Link |
 |--------|---------|---------|------|
@@ -307,6 +309,7 @@ func createReleaseBody(name string, plugins []PluginRelease, publicKey *minisign
 		for _, p := range existingPlugins {
 			sb.WriteString(fmt.Sprintf("| %s | %s | %s | [Download](%s) |\n", p.PluginName, p.PluginVersion, p.ReleaseTag, p.URL))
 		}
+		sb.WriteString("</details>\n")
 		sb.WriteString("\n")
 	}
 


### PR DESCRIPTION
Update the release notes body to collapse previously released plugins so users can focus on just what changed.