### PR TITLE
add a utility to download plugins from GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .build/
 .idea/
 .vscode/
-minisign.*
 node_modules/
 tests/testdata/**/buf.gen.yaml
 tests/testdata/**/gen/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,7 +40,6 @@ linters:
   enable-all: true
   disable:
     - exhaustruct
-    - nilnil
     - varnamelen
     # Other disabled linters
     - cyclop            # covered by gocyclo

--- a/cmd/download-plugins/main.go
+++ b/cmd/download-plugins/main.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	_ "embed"
+	"encoding/hex"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"aead.dev/minisign"
+	"github.com/google/go-github/v48/github"
+
+	"github.com/bufbuild/plugins/internal/release"
+)
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatalf("failed to download release: %v", err)
+	}
+}
+
+func run() error {
+	var (
+		minisignPublicKey string
+		releaseTag        string
+	)
+	flag.StringVar(&minisignPublicKey, "minisign-public-key", "", "path to minisign public key file")
+	flag.StringVar(&releaseTag, "release-tag", "", "release to download (default: latest release)")
+	flag.Parse()
+
+	if len(flag.Args()) != 1 {
+		_, _ = os.Stderr.WriteString("usage: download-plugins <dir>\n")
+		flag.PrintDefaults()
+		os.Exit(2)
+	}
+	downloadDir := flag.Arg(0)
+
+	ctx := context.Background()
+	client := release.NewClient(ctx)
+
+	publicKey, err := loadPublicKey(minisignPublicKey)
+	if err != nil {
+		return err
+	}
+
+	var githubRelease *github.RepositoryRelease
+	if releaseTag == "" {
+		githubRelease, err = client.GetLatestRelease(ctx, release.GithubOwnerBufbuild, release.GithubRepoPlugins)
+		if err != nil {
+			return err
+		}
+	} else {
+		githubRelease, err = client.GetReleaseByTag(ctx, release.GithubOwnerBufbuild, release.GithubRepoPlugins, releaseTag)
+		if err != nil {
+			return err
+		}
+	}
+
+	pluginReleases, err := client.LoadPluginReleases(ctx, githubRelease, publicKey)
+	if err != nil {
+		return err
+	}
+	for _, pluginRelease := range pluginReleases.Releases {
+		exists, err := pluginExistsMatchingDigest(pluginRelease, downloadDir)
+		if err != nil {
+			return err
+		}
+		if exists {
+			log.Printf("already downloaded: %s", filepath.Join(downloadDir, filepath.Base(pluginRelease.URL)))
+		} else if err := downloadReleaseToDir(ctx, client.GitHub.Client(), pluginRelease, downloadDir); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func pluginExistsMatchingDigest(plugin release.PluginRelease, downloadDir string) (bool, error) {
+	digest, err := release.CalculateDigest(filepath.Join(downloadDir, filepath.Base(plugin.URL)))
+	if err != nil {
+		return false, err
+	}
+	return digest == plugin.PluginZipDigest, nil
+}
+
+func downloadReleaseToDir(ctx context.Context, client *http.Client, plugin release.PluginRelease, downloadDir string) error {
+	expectedDigest, err := parseDigest(plugin.PluginZipDigest)
+	if err != nil {
+		return err
+	}
+	f, err := os.CreateTemp(downloadDir, "."+strings.ReplaceAll(plugin.PluginName, "/", "-"))
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := f.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
+			log.Printf("failed to close temporary file: %v", err)
+		}
+		if err := os.Remove(f.Name()); err != nil && !errors.Is(err, os.ErrNotExist) {
+			log.Printf("failed to remove temporary file %q: %v", f.Name(), err)
+		}
+	}()
+	log.Printf("downloading: %v", plugin.URL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, plugin.URL, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Printf("failed to close response: %v", err)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to download %s: %s", plugin.URL, resp.Status)
+	}
+	digest := sha256.New()
+	w := io.MultiWriter(f, digest)
+	if _, err := io.Copy(w, resp.Body); err != nil {
+		return err
+	}
+	sha256Digest := hex.EncodeToString(digest.Sum(nil))
+	if sha256Digest != expectedDigest {
+		return fmt.Errorf("checksum mismatch for %s: %q (expected) != %q (actual)", plugin.URL, expectedDigest, sha256Digest)
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(f.Name(), filepath.Join(downloadDir, filepath.Base(plugin.URL))); err != nil {
+		return err
+	}
+	return nil
+}
+
+func parseDigest(digestStr string) (string, error) {
+	digestType, digest, found := strings.Cut(digestStr, ":")
+	if !found {
+		return "", fmt.Errorf("malformed digest: %q", digestStr)
+	}
+	if digestType != "sha256" {
+		return "", fmt.Errorf("unsupported digest: %q", digestType)
+	}
+	if _, err := hex.DecodeString(digest); err != nil {
+		return "", fmt.Errorf("malformed digest %q: %w", digest, err)
+	}
+	return digest, nil
+}
+
+func loadPublicKey(path string) (minisign.PublicKey, error) {
+	if path == "" {
+		return release.DefaultPublicKey()
+	}
+	return minisign.PublicKeyFromFile(path)
+}

--- a/cmd/release/main.go
+++ b/cmd/release/main.go
@@ -176,12 +176,7 @@ func (c *command) calculateNewReleasePlugins(currentRelease *release.PluginRelea
 	var newPlugins []release.PluginRelease
 	var existingPlugins []release.PluginRelease
 
-	n := 0
 	if err := plugin.Walk(c.rootDir, func(plugin *plugin.Plugin) error {
-		n++
-		if n > 4 {
-			return nil
-		}
 		identity, err := bufpluginref.PluginIdentityForString(plugin.Name)
 		if err != nil {
 			return err

--- a/internal/release/github.go
+++ b/internal/release/github.go
@@ -1,0 +1,171 @@
+package release
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"aead.dev/minisign"
+	"github.com/google/go-github/v48/github"
+	"github.com/hashicorp/go-retryablehttp"
+	"golang.org/x/oauth2"
+)
+
+type GithubRepo string
+type GithubOwner string
+
+const (
+	GithubOwnerBufbuild GithubOwner = "bufbuild"
+	GithubRepoPlugins   GithubRepo  = "plugins"
+)
+
+var ErrNotFound = errors.New("release not found")
+
+type Client struct {
+	GitHub *github.Client
+}
+
+// NewClient returns a new HTTP client which can be used to perform actions on GitHub releases.
+func NewClient(ctx context.Context) *Client {
+	var httpClient *http.Client
+	if ghToken := os.Getenv("GITHUB_TOKEN"); ghToken != "" {
+		log.Printf("creating authenticated client with GITHUB_TOKEN")
+		ts := oauth2.StaticTokenSource(
+			&oauth2.Token{AccessToken: ghToken},
+		)
+		httpClient = oauth2.NewClient(ctx, ts)
+	} else {
+		httpClient = retryablehttp.NewClient().StandardClient()
+	}
+	return &Client{
+		GitHub: github.NewClient(httpClient),
+	}
+}
+
+// CreateRelease creates a new GitHub release under the owner and repo.
+func (c *Client) CreateRelease(ctx context.Context, owner GithubOwner, repo GithubRepo, release *github.RepositoryRelease) (*github.RepositoryRelease, error) {
+	repositoryRelease, _, err := c.GitHub.Repositories.CreateRelease(ctx, string(owner), string(repo), release)
+	if err != nil {
+		return nil, err
+	}
+	return repositoryRelease, nil
+}
+
+// EditRelease performs an update of editable properties of a release (i.e. marking it not as a draft).
+func (c *Client) EditRelease(ctx context.Context, owner GithubOwner, repo GithubRepo, releaseID int64, releaseChanges *github.RepositoryRelease) (*github.RepositoryRelease, error) {
+	release, _, err := c.GitHub.Repositories.EditRelease(ctx, string(owner), string(repo), releaseID, releaseChanges)
+	if err != nil {
+		return nil, err
+	}
+	return release, nil
+}
+
+// UploadReleaseAsset uploads the specified file to the release.
+func (c *Client) UploadReleaseAsset(ctx context.Context, owner GithubOwner, repo GithubRepo, releaseID int64, filename string) error {
+	f, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	_, _, err = c.GitHub.Repositories.UploadReleaseAsset(ctx, string(owner), string(repo), releaseID, &github.UploadOptions{
+		Name: filepath.Base(filename),
+	}, f)
+	return err
+}
+
+// GetLatestRelease returns information about the latest GitHub release for the given org and repo (i.e. 'bufbuild', 'plugins').
+// If no release is found, returns ErrReleaseNotFound.
+func (c *Client) GetLatestRelease(ctx context.Context, owner GithubOwner, repo GithubRepo) (*github.RepositoryRelease, error) {
+	repositoryRelease, resp, err := c.GitHub.Repositories.GetLatestRelease(ctx, string(owner), string(repo))
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			// no latest release
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return repositoryRelease, nil
+}
+
+// GetReleaseByTag returns information about a given release (by tag name).
+func (c *Client) GetReleaseByTag(ctx context.Context, owner GithubOwner, repo GithubRepo, tag string) (*github.RepositoryRelease, error) {
+	repositoryRelease, resp, err := c.GitHub.Repositories.GetReleaseByTag(ctx, string(owner), string(repo), tag)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			// no latest release
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return repositoryRelease, nil
+}
+
+func getOrgRepoFromReleaseURL(url string) (string, string, error) {
+	_, orgRepo, found := strings.Cut(url, "/repos/")
+	if !found {
+		return "", "", fmt.Errorf("unsupported release URL format - no /repos/ found: %q", url)
+	}
+	orgRepo, _, found = strings.Cut(orgRepo, "/releases/")
+	if !found {
+		return "", "", fmt.Errorf("unsupported release URL format - no /releases/ found: %q", url)
+	}
+	org, repo, found := strings.Cut(orgRepo, "/")
+	if !found {
+		return "", "", fmt.Errorf("unsupported release URL format no org/repo found: %q", url)
+	}
+	return org, repo, nil
+}
+
+// LoadPluginReleases loads the plugin-releases.json file from the specified GitHub release.
+// It will additionally verify the minisign signature of the release if passed a valid minisign.PublicKey.
+func (c *Client) LoadPluginReleases(ctx context.Context, release *github.RepositoryRelease, publicKey minisign.PublicKey) (*PluginReleases, error) {
+	releasesJSONBytes, err := c.downloadAsset(ctx, release, PluginReleasesFile)
+	if err != nil {
+		return nil, err
+	}
+	releasesJSONMinisigBytes, err := c.downloadAsset(ctx, release, PluginReleasesSignatureFile)
+	if err != nil && !errors.Is(err, ErrNotFound) {
+		return nil, err
+	}
+	if !publicKey.Equal(minisign.PublicKey{}) && !minisign.Verify(publicKey, releasesJSONBytes, releasesJSONMinisigBytes) {
+		return nil, fmt.Errorf("release %s file %q doesn't match signature %q", release.GetName(), PluginReleasesFile, PluginReleasesSignatureFile)
+	}
+	var releases PluginReleases
+	if err := json.Unmarshal(releasesJSONBytes, &releases); err != nil {
+		return nil, err
+	}
+	return &releases, nil
+}
+
+func (c *Client) downloadAsset(ctx context.Context, release *github.RepositoryRelease, assetName string) ([]byte, error) {
+	var assetID int64
+	for _, asset := range release.Assets {
+		if asset.GetName() == assetName {
+			assetID = asset.GetID()
+			break
+		}
+	}
+	if assetID == 0 {
+		return nil, ErrNotFound
+	}
+	org, repo, err := getOrgRepoFromReleaseURL(release.GetURL())
+	if err != nil {
+		return nil, err
+	}
+	rc, _, err := c.GitHub.Repositories.DownloadReleaseAsset(ctx, org, repo, assetID, http.DefaultClient)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := rc.Close(); err != nil {
+			log.Printf("failed to close: %v", err)
+		}
+	}()
+	return io.ReadAll(rc)
+}

--- a/internal/release/minisign.pub
+++ b/internal/release/minisign.pub
@@ -1,0 +1,2 @@
+untrusted comment: minisign public key: 4C9786A7A6FF1D33
+RWQzHf+mp4aXTCoW8biJg4wlLiLJSallqQXbJS8C2qxFz/8In1q0Hfn5

--- a/internal/release/publickey.go
+++ b/internal/release/publickey.go
@@ -1,0 +1,18 @@
+package release
+
+import (
+	_ "embed"
+
+	"aead.dev/minisign"
+)
+
+//go:embed minisign.pub
+var minisignPublicKey []byte
+
+func DefaultPublicKey() (minisign.PublicKey, error) {
+	var publicKey minisign.PublicKey
+	if err := publicKey.UnmarshalText(minisignPublicKey); err != nil {
+		return minisign.PublicKey{}, err
+	}
+	return publicKey, nil
+}

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -1,0 +1,62 @@
+package release
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"log"
+	"os"
+	"time"
+)
+
+// Utilities for creating or consuming GitHub plugin releases.
+
+const (
+	PluginReleasesFile          = "plugin-releases.json"
+	PluginReleasesSignatureFile = PluginReleasesFile + ".minisig"
+)
+
+type Status int
+
+const (
+	StatusExisting Status = iota
+	StatusNew
+	StatusUpdated
+)
+
+type PluginReleases struct {
+	Releases []PluginRelease `json:"releases"`
+}
+
+type PluginRelease struct {
+	PluginName       string    `json:"name"`           // org/name for the plugin (without remote)
+	PluginVersion    string    `json:"version"`        // version of the plugin (including 'v' prefix)
+	PluginZipDigest  string    `json:"zip_digest"`     // <digest-type>:<digest> for plugin .zip download
+	PluginYAMLDigest string    `json:"yaml_digest"`    // <digest-type>:<digest> for buf.plugin.yaml
+	ImageID          string    `json:"image_id"`       // <digest-type>:<digest> - https://github.com/opencontainers/image-spec/blob/main/config.md#imageid
+	RegistryImage    string    `json:"registry_image"` // ghcr.io/bufbuild/plugins-<org>-<name>@<digest-type>:<digest>
+	ReleaseTag       string    `json:"release_tag"`    // GitHub release tag - i.e. 20221121.1
+	URL              string    `json:"url"`            // URL to GitHub release zip file for the plugin - i.e. https://github.com/bufbuild/plugins/releases/download/20221121.1/bufbuild-connect-go-v1.1.0.zip
+	LastUpdated      time.Time `json:"last_updated"`
+	Status           Status    `json:"-"`
+}
+
+// CalculateDigest will calculate the sha256 digest of the given file.
+// It returns a string in the format: '<digest-type>:<digest>'.
+func CalculateDigest(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			log.Printf("failed to close: %v", err)
+		}
+	}()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, f); err != nil {
+		return "", err
+	}
+	hashBytes := hash.Sum(nil)
+	return "sha256:" + hex.EncodeToString(hashBytes), nil
+}


### PR DESCRIPTION
Create a download-plugins CLI which can be used to download the latest plugins from GitHub (and verify both the signature of plugin-releases.json and the SHA-256 sums of each zip file).

As part of this work, refactor reusable code from the current release command into the internal/release package.