### PR TITLE
migrate off deprecated github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,17 +17,17 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: nrwl/last-successful-commit-action@f74ee67ed77cc6a9f54c742c8c04b86ae33906fe
+    - uses: rwl/nx-set-shas@177b48373c6dc583ce0d9257ffb484bdd232fedf
       id: last_successful_commit_push
       with:
-        branch: ${{ github.ref_name }}
+        main-branch-name: ${{ github.ref_name }}
         workflow_id: 'ci.yml'
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Get changed files
       id: changed-files
       uses: tj-actions/changed-files@8a4cc4fbd67975557b6d85dd302f5f9400b9c92e
       with:
-        base_sha: ${{ steps.last_successful_commit_push.outputs.commit_hash }}
+        base_sha: ${{ steps.last_successful_commit_push.outputs.base }}
         files: |
           plugins/**
         files_ignore: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
 
 # Ref: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions
 permissions:
+  actions: read
+  contents: read
   packages: write
 
 concurrency: ci-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: rwl/nx-set-shas@177b48373c6dc583ce0d9257ffb484bdd232fedf
+    - uses: nrwl/nx-set-shas@177b48373c6dc583ce0d9257ffb484bdd232fedf
       id: last_successful_commit_push
       with:
         main-branch-name: ${{ github.ref_name }}


### PR DESCRIPTION
Migrate from last-successful-commit-action to nx-set-shas. This reflects upstream changes made in tj-actions/changed-files:

https://github.com/tj-actions/changed-files/pull/822