### PR TITLE
small improvements to download-plugins

### DIFF
--- a/internal/fetchclient/fetchclient.go
+++ b/internal/fetchclient/fetchclient.go
@@ -47,7 +47,9 @@ func New(ctx context.Context) *Client {
 		)
 		client = oauth2.NewClient(ctx, ts)
 	} else {
-		client = retryablehttp.NewClient().StandardClient()
+		retryableClient := retryablehttp.NewClient()
+		retryableClient.Logger = nil
+		client = retryableClient.StandardClient()
 	}
 	return &Client{
 		httpClient: client,

--- a/internal/release/github.go
+++ b/internal/release/github.go
@@ -42,7 +42,9 @@ func NewClient(ctx context.Context) *Client {
 		)
 		httpClient = oauth2.NewClient(ctx, ts)
 	} else {
-		httpClient = retryablehttp.NewClient().StandardClient()
+		client := retryablehttp.NewClient()
+		client.Logger = nil
+		httpClient = client.StandardClient()
 	}
 	return &Client{
 		GitHub: github.NewClient(httpClient),


### PR DESCRIPTION
Remove DEBUG logging of every HTTP request. Don't log when the plugin exists on disk with the right checksum. Set plugin timestamps to reflect when they were released (this may make it easier to determine which plugins to install or update).