### PR TITLE
add missing plugin dependencies

### DIFF
--- a/plugins/bufbuild/validate-cpp/v0.9.0/buf.plugin.yaml
+++ b/plugins/bufbuild/validate-cpp/v0.9.0/buf.plugin.yaml
@@ -3,6 +3,8 @@ name: buf.build/bufbuild/validate-cpp
 plugin_version: v0.9.0
 source_url: https://github.com/bufbuild/protoc-gen-validate
 description: Generates C++ code to validate Protobuf messages using protoc-gen-validate constraints.
+deps:
+  - plugin: buf.build/protocolbuffers/cpp:v21.12
 output_languages:
   - cpp
 spdx_license_id: Apache-2.0

--- a/plugins/bufbuild/validate-go/v0.9.0/buf.plugin.yaml
+++ b/plugins/bufbuild/validate-go/v0.9.0/buf.plugin.yaml
@@ -3,6 +3,8 @@ name: buf.build/bufbuild/validate-go
 plugin_version: v0.9.0
 source_url: https://github.com/bufbuild/protoc-gen-validate
 description: Generates Go code to validate Protobuf messages using protoc-gen-validate constraints.
+deps:
+  - plugin: buf.build/protocolbuffers/go:v1.28.1
 output_languages:
   - go
 spdx_license_id: Apache-2.0

--- a/plugins/bufbuild/validate-java/v0.9.0/buf.plugin.yaml
+++ b/plugins/bufbuild/validate-java/v0.9.0/buf.plugin.yaml
@@ -3,6 +3,8 @@ name: buf.build/bufbuild/validate-java
 plugin_version: v0.9.0
 source_url: https://github.com/bufbuild/protoc-gen-validate
 description: Generates Java code to validate Protobuf messages using protoc-gen-validate constraints.
+deps:
+  - plugin: buf.build/protocolbuffers/java:v21.12
 output_languages:
   - java
 spdx_license_id: Apache-2.0

--- a/plugins/grpc/cpp/v1.51.1/buf.plugin.yaml
+++ b/plugins/grpc/cpp/v1.51.1/buf.plugin.yaml
@@ -3,6 +3,8 @@ name: buf.build/grpc/cpp
 plugin_version: v1.51.1
 source_url: https://github.com/grpc/grpc
 description: Generates C++ client and server stubs for the gRPC framework.
+deps:
+  - plugin: buf.build/protocolbuffers/cpp:v21.12
 output_languages:
   - cpp
 spdx_license_id: Apache-2.0

--- a/plugins/grpc/csharp/v1.51.1/buf.plugin.yaml
+++ b/plugins/grpc/csharp/v1.51.1/buf.plugin.yaml
@@ -3,6 +3,8 @@ name: buf.build/grpc/csharp
 plugin_version: v1.51.1
 source_url: https://github.com/grpc/grpc
 description: Generates C# client and server stubs for the gRPC framework.
+deps:
+  - plugin: buf.build/protocolbuffers/csharp:v21.12
 output_languages:
   - csharp
 spdx_license_id: Apache-2.0

--- a/plugins/grpc/java/v1.51.1/buf.plugin.yaml
+++ b/plugins/grpc/java/v1.51.1/buf.plugin.yaml
@@ -3,6 +3,8 @@ name: buf.build/grpc/java
 plugin_version: v1.51.1
 source_url: https://github.com/grpc/grpc-java
 description: Generates Java client and server stubs for the gRPC framework.
+deps:
+  - plugin: buf.build/protocolbuffers/java:v21.12
 output_languages:
   - java
 spdx_license_id: Apache-2.0

--- a/plugins/grpc/kotlin/v1.3.0/buf.plugin.yaml
+++ b/plugins/grpc/kotlin/v1.3.0/buf.plugin.yaml
@@ -3,6 +3,8 @@ name: buf.build/grpc/kotlin
 plugin_version: v1.3.0
 source_url: https://github.com/grpc/grpc-kotlin
 description: Generates Kotlin client and server stubs for the gRPC framework.
+deps:
+  - plugin: buf.build/protocolbuffers/kotlin:v21.12
 output_languages:
   - kotlin
 spdx_license_id: Apache-2.0

--- a/plugins/grpc/objc/v1.51.1/buf.plugin.yaml
+++ b/plugins/grpc/objc/v1.51.1/buf.plugin.yaml
@@ -3,6 +3,8 @@ name: buf.build/grpc/objc
 plugin_version: v1.51.1
 source_url: https://github.com/grpc/grpc
 description: Generates Objective-C client and server stubs for the gRPC framework.
+deps:
+  - plugin: buf.build/protocolbuffers/objc:v21.12
 output_languages:
   - objective_c
 spdx_license_id: Apache-2.0

--- a/plugins/grpc/php/v1.51.1/buf.plugin.yaml
+++ b/plugins/grpc/php/v1.51.1/buf.plugin.yaml
@@ -3,6 +3,8 @@ name: buf.build/grpc/php
 plugin_version: v1.51.1
 source_url: https://github.com/grpc/grpc
 description: Generates PHP client and server stubs for the gRPC framework.
+deps:
+  - plugin: buf.build/protocolbuffers/php:v21.12
 output_languages:
   - php
 spdx_license_id: Apache-2.0

--- a/plugins/grpc/python/v1.51.1/buf.plugin.yaml
+++ b/plugins/grpc/python/v1.51.1/buf.plugin.yaml
@@ -3,6 +3,8 @@ name: buf.build/grpc/python
 plugin_version: v1.51.1
 source_url: https://github.com/grpc/grpc
 description: Generates Python client and server stubs for the gRPC framework.
+deps:
+  - plugin: buf.build/protocolbuffers/python:v21.12
 output_languages:
   - python
 spdx_license_id: Apache-2.0

--- a/plugins/grpc/ruby/v1.51.1/buf.plugin.yaml
+++ b/plugins/grpc/ruby/v1.51.1/buf.plugin.yaml
@@ -3,6 +3,8 @@ name: buf.build/grpc/ruby
 plugin_version: v1.51.1
 source_url: https://github.com/grpc/grpc
 description: Generates Ruby client and server stubs for the gRPC framework.
+deps:
+  - plugin: buf.build/protocolbuffers/ruby:v21.12
 output_languages:
   - ruby
 spdx_license_id: Apache-2.0

--- a/plugins/grpc/swift/v1.13.1/buf.plugin.yaml
+++ b/plugins/grpc/swift/v1.13.1/buf.plugin.yaml
@@ -3,6 +3,8 @@ name: buf.build/grpc/swift
 plugin_version: v1.13.1
 source_url: https://github.com/grpc/grpc-swift
 description: Generates Swift client and server stubs for the gRPC framework.
+deps:
+  - plugin: buf.build/apple/swift:v1.20.3
 output_languages:
   - swift
 spdx_license_id: Apache-2.0


### PR DESCRIPTION
Even though these plugins don't yet support remote packages, we should add dependencies so that the 'Include Dependencies' works as expected on the plugin details pages. All of these plugins require base types generated from another plugin.