### PR TITLE
Adds protoc-gen-prost v0.2.1

### DIFF
--- a/plugins/community/neoeinstein-prost/source.yaml
+++ b/plugins/community/neoeinstein-prost/source.yaml
@@ -1,0 +1,3 @@
+source:
+  crates:
+    crate_name: protoc-gen-prost

--- a/plugins/community/neoeinstein-prost/v0.2.1/.dockerignore
+++ b/plugins/community/neoeinstein-prost/v0.2.1/.dockerignore
@@ -1,0 +1,2 @@
+*
+!Dockerfile

--- a/plugins/community/neoeinstein-prost/v0.2.1/Dockerfile
+++ b/plugins/community/neoeinstein-prost/v0.2.1/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM rust:1.65.0-alpine3.16 as builder
+FROM rust:1.66.0-alpine3.17 as builder
 RUN apk add --no-cache musl-dev
 WORKDIR /app
 RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,target=/root/target \

--- a/plugins/community/neoeinstein-prost/v0.2.1/Dockerfile
+++ b/plugins/community/neoeinstein-prost/v0.2.1/Dockerfile
@@ -1,0 +1,11 @@
+# syntax=docker/dockerfile:1.4
+FROM rust:1.65.0-alpine3.16 as builder
+RUN apk add --no-cache musl-dev
+WORKDIR /app
+RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,target=/root/target \
+    cargo install protoc-gen-prost --version 0.2.1 --locked --root /app
+
+FROM gcr.io/distroless/static
+COPY --from=builder /app/bin/protoc-gen-prost /protoc-gen-prost
+USER nobody
+ENTRYPOINT ["/protoc-gen-prost"]

--- a/plugins/community/neoeinstein-prost/v0.2.1/buf.plugin.yaml
+++ b/plugins/community/neoeinstein-prost/v0.2.1/buf.plugin.yaml
@@ -1,0 +1,9 @@
+version: v1
+name: buf.build/community/neoeinstein-prost
+plugin_version: v0.2.1
+source_url: https://crates.io/crates/protoc-gen-prost
+description: Generates code using the Prost! code generation engine.
+output_languages:
+  - rust
+spdx_license_id: Apache-2.0
+license_url: https://github.com/neoeinstein/protoc-gen-prost/blob/main/LICENSE

--- a/plugins/community/neoeinstein-prost/v0.2.1/buf.plugin.yaml
+++ b/plugins/community/neoeinstein-prost/v0.2.1/buf.plugin.yaml
@@ -6,4 +6,4 @@ description: Generates code using the Prost! code generation engine.
 output_languages:
   - rust
 spdx_license_id: Apache-2.0
-license_url: https://github.com/neoeinstein/protoc-gen-prost/blob/main/LICENSE
+license_url: https://github.com/neoeinstein/protoc-gen-prost/blob/1daacefaef6a5627d8a33d7258f58f972a845bba/LICENSE

--- a/tests/testdata/buf.build/community/neoeinstein-prost/v0.2.1/eliza/plugin.sum
+++ b/tests/testdata/buf.build/community/neoeinstein-prost/v0.2.1/eliza/plugin.sum
@@ -1,0 +1,1 @@
+h1:P+ng+Q1BRzOatMVDAU9TZH05uohslVqyi4Q6Riyq2Og=

--- a/tests/testdata/buf.build/community/neoeinstein-prost/v0.2.1/petapis/plugin.sum
+++ b/tests/testdata/buf.build/community/neoeinstein-prost/v0.2.1/petapis/plugin.sum
@@ -1,0 +1,1 @@
+h1:jfwgUYMNRZoehWajZoMrEC8OFpv5JfjU7IJqQf5qRzM=


### PR DESCRIPTION
This PR adds the `protoc-gen-prost` plugin. 

Note, I'll tackle [tonic](https://crates.io/crates/protoc-gen-tonic) and [serde](https://crates.io/crates/protoc-gen-prost-serde) from #255 in a subsequent PR as it'll require another solution that is orthogonal to getting this plugin merged in.