### PR TITLE
Update prost source_url to GitHub

### DIFF
--- a/plugins/community/neoeinstein-prost/v0.2.1/buf.plugin.yaml
+++ b/plugins/community/neoeinstein-prost/v0.2.1/buf.plugin.yaml
@@ -1,7 +1,7 @@
 version: v1
 name: buf.build/community/neoeinstein-prost
 plugin_version: v0.2.1
-source_url: https://crates.io/crates/protoc-gen-prost
+source_url: https://github.com/neoeinstein/protoc-gen-prost
 description: Generates code using the Prost! code generation engine.
 output_languages:
   - rust


### PR DESCRIPTION
This PR updates the source_url to GitHub for the prost plugin to be consistent with other plugins.