### PR TITLE
Adds protoc-gen-tonic and protoc-gen-prost-serde

### DIFF
--- a/plugins/community/neoeinstein-prost-serde/source.yaml
+++ b/plugins/community/neoeinstein-prost-serde/source.yaml
@@ -1,0 +1,3 @@
+source:
+  crates:
+    crate_name: protoc-gen-prost-serde

--- a/plugins/community/neoeinstein-prost-serde/v0.2.1/.dockerignore
+++ b/plugins/community/neoeinstein-prost-serde/v0.2.1/.dockerignore
@@ -1,0 +1,2 @@
+*
+!Dockerfile

--- a/plugins/community/neoeinstein-prost-serde/v0.2.1/Dockerfile
+++ b/plugins/community/neoeinstein-prost-serde/v0.2.1/Dockerfile
@@ -1,0 +1,11 @@
+# syntax=docker/dockerfile:1.4
+FROM rust:1.66.0-alpine3.17 as builder
+RUN apk add --no-cache musl-dev
+WORKDIR /app
+RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,target=/root/target \
+    cargo install protoc-gen-prost-serde --version 0.2.1 --locked --root /app
+
+FROM gcr.io/distroless/static
+COPY --from=builder /app/bin/protoc-gen-prost-serde /protoc-gen-prost-serde
+USER nobody
+ENTRYPOINT ["/protoc-gen-prost-serde"]

--- a/plugins/community/neoeinstein-prost-serde/v0.2.1/buf.plugin.yaml
+++ b/plugins/community/neoeinstein-prost-serde/v0.2.1/buf.plugin.yaml
@@ -1,0 +1,9 @@
+version: v1
+name: buf.build/community/neoeinstein-prost-serde
+plugin_version: v0.2.1
+source_url: https://crates.io/crates/protoc-gen-prost-serde
+description: Generates serde serialization implementations that follow the conventions of protobuf-JSON.
+output_languages:
+  - rust
+spdx_license_id: Apache-2.0
+license_url: https://github.com/neoeinstein/protoc-gen-prost/blob/1daacefaef6a5627d8a33d7258f58f972a845bba/LICENSE

--- a/plugins/community/neoeinstein-tonic/source.yaml
+++ b/plugins/community/neoeinstein-tonic/source.yaml
@@ -1,0 +1,3 @@
+source:
+  crates:
+    crate_name: protoc-gen-tonic

--- a/plugins/community/neoeinstein-tonic/v0.2.1/.dockerignore
+++ b/plugins/community/neoeinstein-tonic/v0.2.1/.dockerignore
@@ -1,0 +1,2 @@
+*
+!Dockerfile

--- a/plugins/community/neoeinstein-tonic/v0.2.1/Dockerfile
+++ b/plugins/community/neoeinstein-tonic/v0.2.1/Dockerfile
@@ -1,0 +1,11 @@
+# syntax=docker/dockerfile:1.4
+FROM rust:1.66.0-alpine3.17 as builder
+RUN apk add --no-cache musl-dev
+WORKDIR /app
+RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,target=/root/target \
+    cargo install protoc-gen-tonic --version 0.2.1 --locked --root /app
+
+FROM gcr.io/distroless/static
+COPY --from=builder /app/bin/protoc-gen-tonic /protoc-gen-tonic
+USER nobody
+ENTRYPOINT ["/protoc-gen-tonic"]

--- a/plugins/community/neoeinstein-tonic/v0.2.1/buf.plugin.yaml
+++ b/plugins/community/neoeinstein-tonic/v0.2.1/buf.plugin.yaml
@@ -1,0 +1,9 @@
+version: v1
+name: buf.build/community/neoeinstein-tonic
+plugin_version: v0.2.1
+source_url: https://crates.io/crates/protoc-gen-tonic
+description: Generates Tonic gRPC server and client code using the Prost! code generation engine.
+output_languages:
+  - rust
+spdx_license_id: Apache-2.0
+license_url: https://github.com/neoeinstein/protoc-gen-prost/blob/1daacefaef6a5627d8a33d7258f58f972a845bba/LICENSE


### PR DESCRIPTION
Closes https://github.com/bufbuild/plugins/issues/96 by adding:

- [protoc-gen-tonic](https://crates.io/crates/protoc-gen-tonic)
- [protoc-gen-prost-serde](https://crates.io/crates/protoc-gen-prost-serde)

- [ ] Fix tests for plugins that rely on insertion points. Picking up the discussion in:
          - https://github.com/bufbuild/plugins/pull/255#issuecomment-1336485652
          - https://github.com/bufbuild/plugins/pull/255#issuecomment-1343014005