### PR TITLE
Create scalapb-validate plugin

### DIFF
--- a/plugins/community/scalapb-validate/source.yaml
+++ b/plugins/community/scalapb-validate/source.yaml
@@ -1,0 +1,4 @@
+source:
+  github:
+    owner: scalapb
+    repository: scalapb-validate

--- a/plugins/community/scalapb-validate/v0.3.3/.dockerignore
+++ b/plugins/community/scalapb-validate/v0.3.3/.dockerignore
@@ -1,0 +1,2 @@
+*
+!Dockerfile

--- a/plugins/community/scalapb-validate/v0.3.3/Dockerfile
+++ b/plugins/community/scalapb-validate/v0.3.3/Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1.4
+FROM debian:bullseye-20230109 AS build
+
+ARG TARGETARCH
+
+RUN apt-get update \
+ && apt-get install -y curl
+
+#This script embeds the the .class files and is a self contained jvm protoc plugin. See https://scalapb.github.io/docs/scalapbc/#using-scalapb-as-a-proper-protoc-plugin for more details
+RUN curl -fsSL -o protoc-gen-scalapb-validate.jar https://repo1.maven.org/maven2/com/thesamet/scalapb/protoc-gen-scalapb-validate/0.3.3/protoc-gen-scalapb-validate-0.3.3-unix.sh
+
+FROM gcr.io/distroless/java11-debian11
+COPY --from=build --link /protoc-gen-scalapb-validate.jar .
+USER nobody
+ENTRYPOINT [ "/usr/bin/java", "-jar", "/protoc-gen-scalapb-validate.jar"]

--- a/plugins/community/scalapb-validate/v0.3.3/buf.plugin.yaml
+++ b/plugins/community/scalapb-validate/v0.3.3/buf.plugin.yaml
@@ -2,7 +2,7 @@ version: v1
 name: buf.build/community/scalapb-validate
 plugin_version: v0.3.3
 source_url: https://github.com/scalapb/scalapb-validate
-description: Generates validated messages using protoc-gen-validate (PGV) descriptors
+description: Generates Scala code to validate Protobuf messages using protoc-gen-validate constraints.
 output_languages:
   - scala
 spdx_license_id: Apache-2.0

--- a/plugins/community/scalapb-validate/v0.3.3/buf.plugin.yaml
+++ b/plugins/community/scalapb-validate/v0.3.3/buf.plugin.yaml
@@ -1,0 +1,9 @@
+version: v1
+name: buf.build/community/scalapb-validate
+plugin_version: v0.3.3
+source_url: https://github.com/scalapb/scalapb-validate
+description: Generates validated messages using protoc-gen-validate (PGV) descriptors
+output_languages:
+  - scala
+spdx_license_id: Apache-2.0
+license_url: https://github.com/scalapb/scalapb-validate/blob/v0.3.3/LICENSE


### PR DESCRIPTION
Resolves #304 

Make test command doesn't result in a gen file and the test fails. I believe something is going wrong internally but I'm not sure how to introspect.

Running this built container in the alpha release results in messages like:
`Failure: internal error, contact support, reference code: e311f1`