### PR TITLE
fix fetch versions for grpc-gateway

### DIFF
--- a/plugins/grpc-ecosystem/gateway/source.yaml
+++ b/plugins/grpc-ecosystem/gateway/source.yaml
@@ -1,3 +1,4 @@
 source:
-  goproxy:
-    name: github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway
+  github:
+    owner: grpc-ecosystem
+    repository: grpc-gateway


### PR DESCRIPTION
Use the same configuration as protoc-gen-openapiv2 (which comes from the same repository).