### PR TITLE
Upload release to GCS bucket

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,3 +41,6 @@ jobs:
         if: always()
         run: |
           rm -fv minisign.key
+  upload:
+    needs: release
+    uses: ./.github/workflows/upload.yml

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -1,0 +1,45 @@
+name: Upload to GCS
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    if: github.repository == 'bufbuild/plugins'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository code
+        uses: actions/checkout@v3
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19.x
+          check-latest: true
+          cache: true
+      - name: Cache Plugins
+        id: cache-plugins
+        uses: actions/cache@v3
+        with:
+          path: downloads
+          key: plugin-downloads
+      - name: Download Plugins
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          go run ./cmd/download-plugins downloads
+        # uses https://cloud.google.com/iam/docs/workload-identity-federation to
+        # swap a GitHub OIDC token for GCP service account credentials, allowing
+        # this workflow to manage the buf-plugins bucket
+      - name: Auth To GCP
+        uses: google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d
+        with:
+          workload_identity_proider: projects/491113660045/locations/global/workloadIdentityPools/plugins-workload-pool/providers/plugins-workload-provider
+          service_account: buf-plugins-1-publisher@buf-plugins-1.iam.gserviceaccount.com
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@d51b5346f85640ec2aa2fa057354d2b82c2fcbce
+      - name: Upload To Release Bucket
+        run: gsutil rsync -r downloads gs://buf-plugins


### PR DESCRIPTION
Update the release workflow to call the upload workflow when a release is completed. Add an upload workflow which downloads (and caches) the latest release and uses `gsutil rsync` to copy its contents to a GCS bucket.