### PR TITLE
Fix source_url in grpc-ecosystem/grpc-gateway

### DIFF
--- a/plugins/grpc-ecosystem/gateway/v2.15.0/buf.plugin.yaml
+++ b/plugins/grpc-ecosystem/gateway/v2.15.0/buf.plugin.yaml
@@ -1,7 +1,7 @@
 version: v1
 name: buf.build/grpc-ecosystem/gateway
 plugin_version: v2.15.0
-source_url: https://github.com/grpc/grpc-gateway
+source_url: https://github.com/grpc-ecosystem/grpc-gateway
 description: gRPC to JSON proxy generator following the gRPC HTTP spec.
 output_languages:
   - go


### PR DESCRIPTION
The source_url in buf.plugin.yaml for grpc-gateway seemed to be wrong, so I fixed it.