### PR TITLE
Update bufbuild/connect-es runtime dep

### DIFF
--- a/plugins/bufbuild/connect-es/v0.8.1/buf.plugin.yaml
+++ b/plugins/bufbuild/connect-es/v0.8.1/buf.plugin.yaml
@@ -13,7 +13,7 @@ registry:
     import_style: module
     rewrite_import_path_suffix: connect.js
     deps:
-      - package: '@bufbuild/connect-web'
+      - package: '@bufbuild/connect'
         version: ^0.8.1
 spdx_license_id: Apache-2.0
 license_url: https://github.com/bufbuild/connect-es/blob/v0.8.1/LICENSE


### PR DESCRIPTION
Fix bufbuild/connect-es runtime dep, where the generated code depends on 

https://www.npmjs.com/package/@bufbuild/connect

And the adapters are imported separately:

https://www.npmjs.com/package/@bufbuild/connect-web
https://www.npmjs.com/package/@bufbuild/connect-node

