### PR TITLE
Automate upgrades of Docker base images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,18 +8,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-  # go plugin
+  # plugin base images
   - package-ecosystem: "docker"
-    directory: "/plugins/bufbuild/connect-go/v1.1.0"
-    schedule:
-      interval: "weekly"
-  # dart plugin
-  - package-ecosystem: "docker"
-    directory: "/plugins/protocolbuffers/dart/v20.0.1"
-    schedule:
-      interval: "weekly"
-  # swift plugin
-  - package-ecosystem: "docker"
-    directory: "/plugins/apple/swift/v1.20.3"
+    directory: "/.github/docker"
     schedule:
       interval: "weekly"

--- a/.github/docker/Dockerfile.dart
+++ b/.github/docker/Dockerfile.dart
@@ -1,0 +1,3 @@
+FROM dart:2.18.3-sdk
+
+CMD echo this is a dummy file used to automate dependency upgrades for plugins

--- a/.github/docker/Dockerfile.debian
+++ b/.github/docker/Dockerfile.debian
@@ -1,0 +1,3 @@
+FROM debian:bullseye-20221114
+
+CMD echo this is a dummy file used to automate dependency upgrades for plugins

--- a/.github/docker/Dockerfile.golang
+++ b/.github/docker/Dockerfile.golang
@@ -1,0 +1,3 @@
+FROM golang:1.19.2-bullseye
+
+CMD echo this is a dummy file used to automate dependency upgrades for plugins

--- a/.github/docker/Dockerfile.node
+++ b/.github/docker/Dockerfile.node
@@ -1,0 +1,3 @@
+FROM node:18.14.0-alpine3.17
+
+CMD echo this is a dummy file used to automate dependency upgrades for plugins

--- a/.github/docker/Dockerfile.rust
+++ b/.github/docker/Dockerfile.rust
@@ -1,0 +1,3 @@
+FROM rust:1.68.0-alpine3.17
+
+CMD echo this is a dummy file used to automate dependency upgrades for plugins

--- a/.github/docker/Dockerfile.swift
+++ b/.github/docker/Dockerfile.swift
@@ -1,0 +1,3 @@
+FROM swift:5.7.1-focal
+
+CMD echo this is a dummy file used to automate dependency upgrades for plugins


### PR DESCRIPTION
These Dockerfiles will be updated by dependabot automatically and used as input when creating new versions of plugins by the fetch-versions utility.