### PR TITLE
Simplify plugins build process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: set PLUGINS from workflow inputs
-      run: echo "PLUGINS=${inputs.plugins}" >> $GITHUB_ENV
+      if: ${{ inputs.plugins }}
+      run: echo "PLUGINS=${{ inputs.plugins }}" >> $GITHUB_ENV
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,12 @@ name: ci
 on:
   push:
     branches: [ "main" ]
-  workflow_dispatch: {} # support manual runs
+  workflow_dispatch:
+    inputs:
+      plugins:
+        description: "Plugins to build and publish (i.e. connect-go:latest, connect-go, grpc/java:v1.53.0)"
+        default: ''
+        type: string
 
 # Ref: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions
 permissions:
@@ -16,6 +21,8 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
+    - name: set PLUGINS from workflow inputs
+      run: echo "PLUGINS=${inputs.plugins}" >> $GITHUB_ENV
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
@@ -44,6 +51,15 @@ jobs:
         go-version: 1.20.x
         check-latest: true
         cache: true
+    - name: Set PLUGINS env var from changed files
+      env:
+        ALL_MODIFIED_FILES: ${{ steps.changed-files.outputs.all_modified_files }}
+        ANY_MODIFIED: ${{ steps.changed-files.outputs.any_modified }}
+      run: |
+        val=`go run ./internal/cmd/changed-plugins .`
+        if [[ -n "${val}" && -z "${PLUGINS}" ]]; then
+          echo "PLUGINS=${val}" >> $GITHUB_ENV
+        fi
     - name: Install buf cli
       uses: bufbuild/buf-setup-action@v1.15.1
       with:
@@ -69,14 +85,8 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build
-      env:
-        ALL_MODIFIED_FILES: ${{ steps.changed-files.outputs.all_modified_files }}
-        ANY_MODIFIED: ${{ steps.changed-files.outputs.any_modified }}
       shell: bash
       run: make DOCKER_ORG="ghcr.io/bufbuild" DOCKER_BUILD_EXTRA_ARGS="--push"
     - name: Test
-      env:
-        ALL_MODIFIED_FILES: ${{ steps.changed-files.outputs.all_modified_files }}
-        ANY_MODIFIED: ${{ steps.changed-files.outputs.any_modified }}
       shell: bash
       run: make test DOCKER_ORG="ghcr.io/bufbuild"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,12 @@ name: pr
 on:
   pull_request:
     branches: [ "main" ]
-  workflow_dispatch: {} # support manual runs
+  workflow_dispatch:
+    inputs:
+      plugins:
+        description: "Plugins to build and publish (i.e. connect-go:latest, connect-go, grpc/java:v1.53.0)"
+        default: ''
+        type: string
 
 # Prevent writing to the repository using the CI token.
 # Ref: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions
@@ -19,6 +24,8 @@ jobs:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
     runs-on: ubuntu-latest
     steps:
+    - name: set PLUGINS from workflow inputs
+      run: echo "PLUGINS=${inputs.plugins}" >> $GITHUB_ENV
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
@@ -42,6 +49,15 @@ jobs:
         go-version: 1.20.x
         check-latest: true
         cache: true
+    - name: Set PLUGINS env var from changed files
+      env:
+        ALL_MODIFIED_FILES: ${{ steps.changed-files.outputs.all_modified_files }}
+        ANY_MODIFIED: ${{ steps.changed-files.outputs.any_modified }}
+      run: |
+        val=`go run ./internal/cmd/changed-plugins .`
+        if [[ -n "${val}" && -z "${PLUGINS}" ]]; then
+          echo "PLUGINS=${val}" >> $GITHUB_ENV
+        fi
     - name: Install buf cli
       uses: bufbuild/buf-setup-action@v1.15.1
       with:
@@ -67,14 +83,8 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build
-      env:
-        ALL_MODIFIED_FILES: ${{ steps.changed-files.outputs.all_modified_files }}
-        ANY_MODIFIED: ${{ steps.changed-files.outputs.any_modified }}
       shell: bash
       run: make
     - name: Test
-      env:
-        ALL_MODIFIED_FILES: ${{ steps.changed-files.outputs.all_modified_files }}
-        ANY_MODIFIED: ${{ steps.changed-files.outputs.any_modified }}
       shell: bash
       run: make test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,7 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: set PLUGINS from workflow inputs
-      run: echo "PLUGINS=${inputs.plugins}" >> $GITHUB_ENV
+      if: ${{ inputs.plugins }}
+      run: echo "PLUGINS=${{ inputs.plugins }}" >> $GITHUB_ENV
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,9 +77,8 @@ Note, although some fields are optional, it is suggested to include as many as p
 
 ## CI/CD
 
-PR builds use [tj-actions/changed-files](https://github.com/tj-actions/changed-files) to determine which plugin(s) need to be rebuilt.
-See [.github/workflows/pr.yaml](.github/workflows/pr.yml) and [cmd/dependency-order/main.go](cmd/dependency-order/main.go) for more details.
-Note that some files (`Makefile`,`tests/*.go`,`tests/testdata/images/*.gz`) require all plugins to be rebuilt.
+Builds use [tj-actions/changed-files](https://github.com/tj-actions/changed-files) to determine which plugin(s) need to be rebuilt.
+See [.github/workflows/pr.yaml](.github/workflows/pr.yml) and [internal/cmd/changed-plugins/main.go](internal/cmd/changed-plugins/main.go) for more details.
 
 We use a combination of a custom command ([cmd/fetcher/main.go](cmd/fetcher/main.go)) and Dependabot to keep dependencies up to date in the project.
 The `fetcher` command will use `source.yaml` files in each plugin to determine if new plugin versions are available.

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,11 @@ PLUGIN_IMAGES := $(patsubst %/buf.plugin.yaml,.build/plugin/%/image,$(PLUGIN_YAM
 
 .PHONY: all
 all: build
+	@if [[ -z "${PLUGINS}" ]]; then \
+		echo "No plugins specified to build with PLUGINS env var."; \
+		echo "See Makefile for example PLUGINS env var usage."; \
+		echo "To build all plugins (will take a long time), build with 'make PLUGINS=all'."; \
+	fi
 
 .PHONY: build
 build: $(PLUGIN_IMAGES)

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -147,6 +147,9 @@ func Load(path string, basedir string) (*Plugin, error) {
 // FilterByPluginsEnv returns matching plugins based on a space separated list of plugins (and optional versions) to include.
 func FilterByPluginsEnv(plugins []*Plugin, pluginsEnv string) ([]*Plugin, error) {
 	if pluginsEnv == "" {
+		return nil, nil
+	}
+	if strings.EqualFold(pluginsEnv, "all") {
 		return plugins, nil
 	}
 	includes, err := parsePluginsEnvVar(pluginsEnv)
@@ -163,9 +166,8 @@ func FilterByPluginsEnv(plugins []*Plugin, pluginsEnv string) ([]*Plugin, error)
 			}
 		}
 		if matched {
+			log.Printf("including plugin: %s", plugin.Relpath)
 			filtered = append(filtered, plugin)
-		} else {
-			log.Printf("excluding plugin: %s", plugin.Relpath)
 		}
 	}
 	return filtered, nil
@@ -178,9 +180,9 @@ func FilterByChangedFiles(plugins []*Plugin, lookuper envconfig.Lookuper) ([]*Pl
 	if err := envconfig.ProcessWith(context.Background(), &changedFiles, lookuper); err != nil {
 		return nil, err
 	}
-	// ANY_MODIFIED env var not set - don't filter anything
+	// ANY_MODIFIED env var not set - filter everything
 	if len(changedFiles.AnyModified) == 0 {
-		return plugins, nil
+		return nil, nil
 	}
 	anyModified, err := strconv.ParseBool(changedFiles.AnyModified)
 	if err != nil {
@@ -207,9 +209,8 @@ func FilterByChangedFiles(plugins []*Plugin, lookuper envconfig.Lookuper) ([]*Pl
 			}
 		}
 		if include {
+			log.Printf("including plugin: %s", plugin.Relpath)
 			filtered = append(filtered, plugin)
-		} else {
-			log.Printf("excluding plugin: %s", plugin.Relpath)
 		}
 	}
 	return filtered, nil

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -36,7 +36,7 @@ func TestFilterByPluginsEnv(t *testing.T) {
 		runFilterByPluginsEnv(t, plugins, "bufbuild/connect-go bufbuild/connect-web:v0.2.1"))
 	assert.Equal(t, filterPluginsByPathPrefixes(t, plugins, "plugins/community/chrusty-jsonschema/"),
 		runFilterByPluginsEnv(t, plugins, "chrusty-jsonschema"))
-	assert.Equal(t, filterPluginsByPathPrefixes(t, plugins, "plugins/"), runFilterByPluginsEnv(t, plugins, ""))
+	assert.Equal(t, filterPluginsByPathPrefixes(t, plugins, "plugins/"), runFilterByPluginsEnv(t, plugins, "all"))
 	latestConnectWeb := getLatestPluginVersionsByName(plugins)["buf.build/bufbuild/connect-web"]
 	require.NotEmpty(t, latestConnectWeb)
 	assert.Equal(t, filterPluginsByPathPrefixes(t, plugins, "plugins/bufbuild/connect-web/"+latestConnectWeb+"/"),

--- a/tests/plugins_test.go
+++ b/tests/plugins_test.go
@@ -12,7 +12,6 @@ import (
 	"text/template"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufplugin/bufpluginconfig"
-	"github.com/sethvargo/go-envconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/mod/sumdb/dirhash"
@@ -175,13 +174,7 @@ func loadAllPlugins(t *testing.T) []*plugin.Plugin {
 func loadFilteredPlugins(t *testing.T) []*plugin.Plugin {
 	t.Helper()
 	plugins := loadAllPlugins(t)
-	var filtered []*plugin.Plugin
-	var err error
-	if pluginsEnv := os.Getenv("PLUGINS"); pluginsEnv != "" {
-		filtered, err = plugin.FilterByPluginsEnv(plugins, pluginsEnv)
-	} else {
-		filtered, err = plugin.FilterByChangedFiles(plugins, envconfig.OsLookuper())
-	}
+	filtered, err := plugin.FilterByPluginsEnv(plugins, os.Getenv("PLUGINS"))
 	require.NoError(t, err)
 	return filtered
 }


### PR DESCRIPTION
Add support for workflow_dispatch (manual builds) to specify the PLUGINS env var to allow for rebuilding certain plugins (bypassing the default logic that uses changed-files actions to determine what to rebuild).

Update the changed-files action to run just once and print out a value which can be used as the PLUGINS env var. This allows us to isolate this logic around github actions to just a single place in the code.

Update places that decide which plugins to run to be more conservative. If no filter parameters are used, don't build any plugins and show an error message. This should make it better for new contributors to this project to more easily get started with building a specific plugin (since no one should really be building all 300+ plugins at this point unless they really mean to do so).