### PR TITLE
Ignore changed-files calculation for manual build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,13 @@ jobs:
         fetch-depth: 0
     - uses: nrwl/nx-set-shas@177b48373c6dc583ce0d9257ffb484bdd232fedf
       id: last_successful_commit_push
+      if: ${{ inputs.plugins != '' }}
       with:
         main-branch-name: ${{ github.ref_name }}
         workflow-id: 'ci.yml'
     - name: Get changed files
       id: changed-files
+      if: ${{ inputs.plugins != '' }}
       uses: tj-actions/changed-files@07f86bcdc42639264ec561c7f175fea5f532b6ce
       with:
         base_sha: ${{ steps.last_successful_commit_push.outputs.base }}
@@ -47,6 +49,7 @@ jobs:
           **/source.yaml
         separator: ","
     - name: Show changed files
+      if: ${{ inputs.plugins != '' }}
       run: |
         echo '${{ toJSON(steps.changed-files.outputs) }}'
     - name: Install Go
@@ -56,6 +59,7 @@ jobs:
         check-latest: true
         cache: true
     - name: Set PLUGINS env var from changed files
+      if: ${{ inputs.plugins != '' }}
       env:
         ALL_MODIFIED_FILES: ${{ steps.changed-files.outputs.all_modified_files }}
         ANY_MODIFIED: ${{ steps.changed-files.outputs.any_modified }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -36,6 +36,7 @@ jobs:
         fetch-depth: 0
     - name: Get changed files
       id: changed-files
+      if: ${{ inputs.plugins != '' }}
       uses: tj-actions/changed-files@07f86bcdc42639264ec561c7f175fea5f532b6ce
       with:
         files: |
@@ -45,6 +46,7 @@ jobs:
           **/source.yaml
         separator: ","
     - name: Show changed files
+      if: ${{ inputs.plugins != '' }}
       run: |
         echo '${{ toJSON(steps.changed-files.outputs) }}'
     - name: Install Go
@@ -54,6 +56,7 @@ jobs:
         check-latest: true
         cache: true
     - name: Set PLUGINS env var from changed files
+      if: ${{ inputs.plugins != '' }}
       env:
         ALL_MODIFIED_FILES: ${{ steps.changed-files.outputs.all_modified_files }}
         ANY_MODIFIED: ${{ steps.changed-files.outputs.any_modified }}


### PR DESCRIPTION
Update the GitHub action workflows to ignore use of changed-files action if we've already gotten a non-empty input to the workflow.