### PR TITLE
Add dockerpush command to run after dockerbuild

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
         default: ''
         type: string
 
+env:
+  DOCKER_ORG: "ghcr:io/bufbuild"
+
 # Ref: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions
 permissions:
   actions: read
@@ -93,7 +96,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Test
-      run: make test DOCKER_ORG="ghcr.io/bufbuild"
+      run: make test
     - name: Push to GHCR
       if: github.repository == 'bufbuild/plugins'
-      run: make DOCKER_ORG="ghcr.io/bufbuild" DOCKER_BUILD_EXTRA_ARGS="--push"
+      run: make dockerpush

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
         type: string
 
 env:
-  DOCKER_ORG: "ghcr:io/bufbuild"
+  DOCKER_ORG: "ghcr.io/bufbuild"
 
 # Ref: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions
 permissions:

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ all: build
 build:
 	@go run ./internal/cmd/dockerbuild -org "$(DOCKER_ORG)" -- $(DOCKER_BUILD_EXTRA_ARGS)
 
+.PHONY: dockerpush
+dockerpush:
+	@go run ./internal/cmd/dockerpush -org "$(DOCKER_ORG)"
+
 .PHONY: test
 test: build
 	go test $(GO_TEST_FLAGS) ./...

--- a/internal/cmd/dockerpush/main.go
+++ b/internal/cmd/dockerpush/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"os"
+
+	"github.com/bufbuild/buf/private/pkg/interrupt"
+
+	"github.com/bufbuild/plugins/internal/docker"
+	"github.com/bufbuild/plugins/internal/plugin"
+)
+
+// dockerpush automates pushing images build by dockerbuild to a remote registry.
+
+func main() {
+	var (
+		dir = flag.String("dir", ".", "Directory path to plugins")
+		org = flag.String("org", "bufbuild", "Docker Organization")
+	)
+	flag.Parse()
+	if err := run(*dir, *org); err != nil {
+		log.Fatalf("failed to build: %v", err)
+	}
+}
+
+func run(basedir string, dockerOrg string) error {
+	ctx, cancel := interrupt.WithCancel(context.Background())
+	defer cancel()
+	plugins, err := plugin.FindAll(basedir)
+	if err != nil {
+		return err
+	}
+	includedPlugins, err := plugin.FilterByPluginsEnv(plugins, os.Getenv("PLUGINS"))
+	if err != nil {
+		return err
+	}
+	if len(includedPlugins) == 0 {
+		return nil // nothing to build
+	}
+	for _, includedPlugin := range includedPlugins {
+		output, err := docker.Push(ctx, includedPlugin, dockerOrg)
+		if err != nil {
+			log.Printf(
+				"docker push of plugin %s:%s failed with err %v:\noutput:\n%s",
+				includedPlugin.Name,
+				includedPlugin.PluginVersion,
+				err,
+				string(output),
+			)
+			return err
+		}
+		log.Printf("pushed plugin %s:%s", includedPlugin.Name, includedPlugin.PluginVersion)
+	}
+	return nil
+}

--- a/internal/cmd/dockerpush/main.go
+++ b/internal/cmd/dockerpush/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/bufbuild/plugins/internal/plugin"
 )
 
-// dockerpush automates pushing images build by dockerbuild to a remote registry.
+// dockerpush automates pushing images built by dockerbuild to a remote registry.
 
 func main() {
 	var (
@@ -37,7 +37,7 @@ func run(basedir string, dockerOrg string) error {
 		return err
 	}
 	if len(includedPlugins) == 0 {
-		return nil // nothing to build
+		return nil // nothing to push
 	}
 	for _, includedPlugin := range includedPlugins {
 		output, err := docker.Push(ctx, includedPlugin, dockerOrg)

--- a/internal/docker/build.go
+++ b/internal/docker/build.go
@@ -1,0 +1,100 @@
+package docker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/bufbuild/buf/private/bufpkg/bufplugin/bufpluginref"
+
+	"github.com/bufbuild/plugins/internal/plugin"
+)
+
+// Build runs a Docker build command for the specified plugin tagging it with the given organization.
+// The args parameter passes any additional arguments to be passed to the build.
+// Returns the combined stdout/stderr of the build along with any error.
+func Build(
+	ctx context.Context,
+	plugin *plugin.Plugin,
+	dockerOrg string,
+	args []string,
+) (_ []byte, retErr error) {
+	dockerCmd, err := exec.LookPath("docker")
+	if err != nil {
+		return nil, err
+	}
+	identity, err := bufpluginref.PluginIdentityForString(plugin.Name)
+	if err != nil {
+		return nil, err
+	}
+	imageName, err := ImageName(plugin, dockerOrg)
+	if err != nil {
+		return nil, err
+	}
+	commonArgs := []string{
+		"buildx",
+		"build",
+		"--label",
+		fmt.Sprintf("build.buf.plugins.config.owner=%s", identity.Owner()),
+		"--label",
+		fmt.Sprintf("build.buf.plugins.config.name=%s", identity.Plugin()),
+		"--label",
+		fmt.Sprintf("build.buf.plugins.config.version=%s", plugin.PluginVersion),
+		"--label",
+		"org.opencontainers.image.source=https://github.com/bufbuild/plugins",
+		"--label",
+		fmt.Sprintf("org.opencontainers.image.description=%s", plugin.Description),
+		"--label",
+		fmt.Sprintf("org.opencontainers.image.licenses=%s", plugin.SPDXLicenseID),
+		"--progress",
+		"plain",
+	}
+	commonArgs = append(commonArgs, args...)
+	f, err := os.Open(filepath.Join(filepath.Dir(plugin.Path), "Dockerfile"))
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		retErr = errors.Join(retErr, f.Close())
+	}()
+	buildStages, err := ParseDockerfileBuildStages(f)
+	if err != nil {
+		return nil, err
+	}
+	for _, stage := range buildStages {
+		// Build each stage of multi-stage build (to improve caching)
+		cmd := exec.CommandContext(
+			ctx,
+			dockerCmd,
+			commonArgs...,
+		)
+		cmd.Args = append(
+			cmd.Args,
+			"--target",
+			stage,
+			"-t",
+			imageName+"-"+stage,
+		)
+		cmd.Args = append(cmd.Args, filepath.Dir(plugin.Path))
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			return output, err
+		}
+	}
+	// Build the final stage of multi-stage build
+	cmd := exec.CommandContext(
+		ctx,
+		dockerCmd,
+		commonArgs...,
+	)
+	cmd.Args = append(
+		cmd.Args,
+		"-t",
+		imageName,
+	)
+	cmd.Args = append(cmd.Args, filepath.Dir(plugin.Path))
+	return cmd.CombinedOutput()
+}

--- a/internal/docker/dockerfile.go
+++ b/internal/docker/dockerfile.go
@@ -1,0 +1,32 @@
+package docker
+
+import (
+	"bufio"
+	"io"
+	"strings"
+)
+
+func ParseDockerfileBuildStages(dockerfile io.Reader) ([]string, error) {
+	s := bufio.NewScanner(dockerfile)
+	var stages []string
+	for s.Scan() {
+		line := strings.TrimSpace(s.Text())
+		fields := strings.Fields(line)
+		if len(fields) < 4 {
+			continue
+		}
+		if !strings.EqualFold(fields[0], "from") {
+			continue
+		}
+		for i := 1; i < len(fields); i++ {
+			if strings.EqualFold(fields[i], "as") && i < len(fields)-1 {
+				stages = append(stages, fields[i+1])
+				break
+			}
+		}
+	}
+	if err := s.Err(); err != nil {
+		return nil, err
+	}
+	return stages, nil
+}

--- a/internal/docker/dockerfile_test.go
+++ b/internal/docker/dockerfile_test.go
@@ -1,0 +1,26 @@
+package docker
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseDockerfileBuildStages(t *testing.T) {
+	t.Parallel()
+	multistage := `
+FROM someimage AS build
+RUN something
+
+FROM --platform=linux/amd64 someotherimage:sometag AS next
+RUN somethingelse
+
+FROM scratch
+CMD dosomething
+`
+	stages, err := ParseDockerfileBuildStages(strings.NewReader(multistage))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"build", "next"}, stages)
+}

--- a/internal/docker/name.go
+++ b/internal/docker/name.go
@@ -1,0 +1,17 @@
+package docker
+
+import (
+	"fmt"
+
+	"github.com/bufbuild/buf/private/bufpkg/bufplugin/bufpluginref"
+	"github.com/bufbuild/plugins/internal/plugin"
+)
+
+// ImageName returns the name of the plugin's tagged image in the given organization.
+func ImageName(plugin *plugin.Plugin, org string) (string, error) {
+	identity, err := bufpluginref.PluginIdentityForString(plugin.Name)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s/plugins-%s-%s:%s", org, identity.Owner(), identity.Plugin(), plugin.PluginVersion), nil
+}

--- a/internal/docker/name.go
+++ b/internal/docker/name.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufplugin/bufpluginref"
+
 	"github.com/bufbuild/plugins/internal/plugin"
 )
 

--- a/internal/docker/plugindocker.go
+++ b/internal/docker/plugindocker.go
@@ -1,0 +1,2 @@
+// Package docker contains utilities for interfacing with Docker (build/push).
+package docker

--- a/internal/docker/push.go
+++ b/internal/docker/push.go
@@ -1,0 +1,28 @@
+package docker
+
+import (
+	"context"
+	"os/exec"
+
+	"github.com/bufbuild/plugins/internal/plugin"
+)
+
+// Push pushes a docker image for the given plugin to the Docker organization.
+// It assumes it has already been built in a previous step.
+func Push(ctx context.Context, plugin *plugin.Plugin, dockerOrg string) ([]byte, error) {
+	dockerCmd, err := exec.LookPath("docker")
+	if err != nil {
+		return nil, err
+	}
+	imageName, err := ImageName(plugin, dockerOrg)
+	if err != nil {
+		return nil, err
+	}
+	cmd := exec.CommandContext(
+		ctx,
+		dockerCmd,
+		"push",
+		imageName,
+	)
+	return cmd.CombinedOutput()
+}


### PR DESCRIPTION
Currently, we're re-running the docker build with the '--push' argument, which unfortunately both triggers a rebuild and pushes the images for the other stages of the Dockerfile (which can be much larger than the actual plugin image).

Add a new utility `dockerpush` to run after `dockerbuild` which only does the push of pre-built images. This should speed up the build and also reduce what we push to GHCR.