### PR TITLE
Update cron intervals

### DIFF
--- a/.github/workflows/fetch_versions.yml
+++ b/.github/workflows/fetch_versions.yml
@@ -2,7 +2,8 @@ name: Fetch latest versions
 
 on:
   schedule:
-    - cron: "0 0 * * *" # Run once a day
+    # Run once a day at 10 AM EST
+    - cron: "0 14 * * *"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,8 @@ name: Create Release
 
 on:
   schedule:
-    - cron: "0 0 * * *" # Run once a day
+    # Run every hour.
+    - cron: "30 * * * *"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Create Release
 
 on:
   schedule:
-    # Run every hour.
-    - cron: "30 * * * *"
+    # At minute 30 past every 6th hour.
+    - cron: "30 */6 * * *"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
I suggest we change the Fetcher to run in the morning 10AM eastern, that way we get a notification to remind us on the same day (instead of 8PM the night before).

And update the Release workflow to run every hour, so from the time we merge the PR it gets release. Although maybe this one we can reduce to 4 hours, no strong preference.