### PR TITLE
Create release from GitHub commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           MINISIGN_PRIVATE_KEY_PASSWORD: ${{ secrets.MINISIGN_PRIVATE_KEY_PASSWORD }}
         run: |
           echo "${MINISIGN_PRIVATE_KEY}" > minisign.key
-          go run ./internal/cmd/release -minisign-private-key minisign.key .
+          go run ./internal/cmd/release -commit ${{ github.sha }} -minisign-private-key minisign.key .
       - name: Clean Up
         if: always()
         run: |


### PR DESCRIPTION
In order to prevent race conditions where commits may be merged at the same time a release is running, always pass the `github.sha` as an argument to the release command.