### PR TITLE
Allow download-plugins to use PLUGINS env var

### DIFF
--- a/cmd/download-plugins/main.go
+++ b/cmd/download-plugins/main.go
@@ -16,10 +16,10 @@ import (
 	"strings"
 
 	"aead.dev/minisign"
-	"github.com/bufbuild/plugins/internal/plugin"
 	"github.com/google/go-github/v50/github"
 	"golang.org/x/mod/semver"
 
+	"github.com/bufbuild/plugins/internal/plugin"
 	"github.com/bufbuild/plugins/internal/release"
 )
 


### PR DESCRIPTION
In order to only download a subset of plugins, update download-plugins to support the same PLUGINS env var supported by other commands. If the env var isn't set or is set to 'all', then no filtering is performed.