### PR TITLE
Improve PLUGINS var handling and validate names

### DIFF
--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufplugin/bufpluginconfig"
 	"github.com/bufbuild/buf/private/pkg/encoding"
@@ -230,7 +231,9 @@ func FilterByChangedFiles(plugins []*Plugin, lookuper envconfig.Lookuper) ([]*Pl
 
 func ParsePluginsEnvVar(pluginsEnv string) ([]IncludePlugin, error) {
 	var includes []IncludePlugin
-	fields := strings.Fields(pluginsEnv)
+	fields := strings.FieldsFunc(pluginsEnv, func(r rune) bool {
+		return unicode.IsSpace(r) || r == ','
+	})
 	for _, field := range fields {
 		field = strings.TrimSpace(field)
 		if field == "" {

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -36,6 +36,8 @@ func TestFilterByPluginsEnv(t *testing.T) {
 	assert.Equal(t, filterPluginsByPathPrefixes(t, plugins, "plugins/bufbuild/connect-go/", "plugins/bufbuild/connect-web/v0.2.1/"),
 		runFilterByPluginsEnv(t, plugins, "connect-go connect-web:v0.2.1"))
 	assert.Equal(t, filterPluginsByPathPrefixes(t, plugins, "plugins/bufbuild/connect-go/", "plugins/bufbuild/connect-web/v0.2.1/"),
+		runFilterByPluginsEnv(t, plugins, "connect-go,connect-web:v0.2.1"))
+	assert.Equal(t, filterPluginsByPathPrefixes(t, plugins, "plugins/bufbuild/connect-go/", "plugins/bufbuild/connect-web/v0.2.1/"),
 		runFilterByPluginsEnv(t, plugins, "bufbuild/connect-go bufbuild/connect-web:v0.2.1"))
 	assert.Equal(t, filterPluginsByPathPrefixes(t, plugins, "plugins/community/chrusty-jsonschema/"),
 		runFilterByPluginsEnv(t, plugins, "chrusty-jsonschema"))

--- a/tests/plugins_test.go
+++ b/tests/plugins_test.go
@@ -139,6 +139,8 @@ func TestBufPluginConfig(t *testing.T) {
 		assert.NotEmpty(t, config.PluginVersion)
 		assert.NotEmpty(t, config.SPDXLicenseID)
 		assert.NotEmpty(t, config.LicenseURL)
+		// Don't allow underscore in plugin names - this would cause issues in remote packages
+		assert.NotContains(t, config.Name.IdentityString(), "_")
 	}
 }
 


### PR DESCRIPTION
Improve the handling of the PLUGINS variable to allow either space or comma separated plugin(s). Update name validation to prevent use of underscores which will cause issues with remote packages in some languages.