### PR TITLE
Disable fetcher for protoc-gen-connect-web

### DIFF
--- a/plugins/bufbuild/connect-web/source.yaml
+++ b/plugins/bufbuild/connect-web/source.yaml
@@ -1,3 +1,4 @@
 source:
+  disabled: true
   npm_registry:
     name: "@bufbuild/protoc-gen-connect-web"


### PR DESCRIPTION
This PR disables fetching new versions for `protoc-gen-connect-web`