### PR TITLE
Add plugin protoc-gen-go-grpc-mock

### DIFF
--- a/plugins/community/sorcererxw-go-grpc-mock/source.yaml
+++ b/plugins/community/sorcererxw-go-grpc-mock/source.yaml
@@ -1,0 +1,4 @@
+source:
+  github:
+    owner: sorcererxw
+    repository: protoc-gen-go-grpc-mock

--- a/plugins/community/sorcererxw-go-grpc-mock/v1.1.1/.dockerignore
+++ b/plugins/community/sorcererxw-go-grpc-mock/v1.1.1/.dockerignore
@@ -1,0 +1,2 @@
+*
+!Dockerfile

--- a/plugins/community/sorcererxw-go-grpc-mock/v1.1.1/Dockerfile
+++ b/plugins/community/sorcererxw-go-grpc-mock/v1.1.1/Dockerfile
@@ -1,0 +1,11 @@
+# syntax=docker/dockerfile:1.4
+FROM golang:1.20.3-bullseye AS build
+RUN --mount=type=cache,target=/go/pkg/mod \
+    CGO_ENABLED=0 \
+    go install -ldflags="-s -w" -trimpath github.com/sorcererxw/protoc-gen-go-grpc-mock@v1.1.1
+
+FROM scratch
+COPY --from=build --link --chown=root:root /etc/passwd /etc/passwd
+COPY --from=build --link --chown=root:root /go/bin/protoc-gen-go-grpc-mock .
+USER nobody
+ENTRYPOINT [ "/protoc-gen-go-grpc-mock" ]

--- a/plugins/community/sorcererxw-go-grpc-mock/v1.1.1/buf.plugin.yaml
+++ b/plugins/community/sorcererxw-go-grpc-mock/v1.1.1/buf.plugin.yaml
@@ -1,0 +1,9 @@
+version: v1
+name: buf.build/community/sorcererxw-go-grpc-mock
+plugin_version: v1.1.1
+source_url: https://github.com/sorcererxw/protoc-gen-go-grpc-mock
+description: Generate Go gRPC service mocks compatible with golang/mock.
+output_languages:
+  - go
+spdx_license_id: MIT
+license_url: https://github.com/sorcererxw/protoc-gen-go-grpc-mock/blob/v1.1.1/LICENSE


### PR DESCRIPTION
This plugin https://github.com/sorcererxw/protoc-gen-go-grpc-mock is used to generate mock files for gRPC, which is very useful for us. 

I wrote the following code by referencing other existing plugins. However, I don't know how to verify if it is feasible. Could you provide some suggestions?