### PR TITLE
Use docker buildx defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,6 @@ jobs:
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@4b4e9c3e2d4531116a6f8ba8e71fc6e2cb6e6c8c
-      with:
-        driver: docker
-        driver-opts: network=host
     - name: Login to Docker Hub
       uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
       with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -74,9 +74,6 @@ jobs:
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@4b4e9c3e2d4531116a6f8ba8e71fc6e2cb6e6c8c
-      with:
-        driver: docker
-        driver-opts: network=host
     - name: Login to Docker Hub
       if: ${{ env.DOCKERHUB_USERNAME != '' }}
       uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a


### PR DESCRIPTION
We are no longer doing anything special with our builds - change our buildx configuration to the default.