### PR TITLE
Update grpc/kotlin to newer dependencies

### DIFF
--- a/plugins/grpc/kotlin/v1.3.0/buf.plugin.yaml
+++ b/plugins/grpc/kotlin/v1.3.0/buf.plugin.yaml
@@ -4,8 +4,8 @@ plugin_version: v1.3.0
 source_url: https://github.com/grpc/grpc-kotlin
 description: Generates Kotlin client and server stubs for the gRPC framework.
 deps:
-  - plugin: buf.build/grpc/java:v1.54.0
-  - plugin: buf.build/protocolbuffers/kotlin:v22.2
+  - plugin: buf.build/grpc/java:v1.54.1
+  - plugin: buf.build/protocolbuffers/kotlin:v22.3
 output_languages:
   - kotlin
 spdx_license_id: Apache-2.0
@@ -14,7 +14,7 @@ registry:
   maven:
     compiler:
       kotlin:
-        version: 1.8.10
+        version: 1.8.21
     deps:
       - io.grpc:grpc-kotlin-stub:1.3.0
       - org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.1


### PR DESCRIPTION
The grpc/kotlin plugin currently doesn't work with remote packages, as it was dependent on a version of protocolbuffers/kotlin that didn't include a fix for #491. Update this plugin to depend on newer dependencies so that it can work with remote packages.