### PR TITLE
Set up Docker buildx in fetch_versions

### DIFF
--- a/.github/workflows/fetch_versions.yml
+++ b/.github/workflows/fetch_versions.yml
@@ -34,6 +34,11 @@ jobs:
         uses: bufbuild/buf-setup-action@v1.19.0
         with:
           github_token: ${{ github.token }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@4b4e9c3e2d4531116a6f8ba8e71fc6e2cb6e6c8c
       - name: Fetch all versions
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
We should use the same Docker config in all the PR jobs that build Docker images.