### PR TITLE
Add comments to pyi plugin files

### DIFF
--- a/plugins/protocolbuffers/pyi/v23.2/BUILD
+++ b/plugins/protocolbuffers/pyi/v23.2/BUILD
@@ -1,3 +1,4 @@
+# Create a standalone binary to generate Python .pyi files
 cc_binary(
     name = "protoc-gen-pyi",
     srcs = ["pyi.cc"],

--- a/plugins/protocolbuffers/pyi/v23.2/pyi.cc
+++ b/plugins/protocolbuffers/pyi/v23.2/pyi.cc
@@ -1,6 +1,7 @@
 #include <google/protobuf/compiler/python/pyi_generator.h>
 #include <google/protobuf/compiler/plugin.h>
 
+// Standalone binary to generate Python .pyi files
 int main(int argc, char *argv[]) {
   google::protobuf::compiler::python::PyiGenerator generator;
   return google::protobuf::compiler::PluginMain(argc, argv, &generator);


### PR DESCRIPTION
We're inconsistently seeing issues when building .php and .pyi together again - ensure that the BUILD and .cc files have different file sizes to ensure Docker doesn't mix contexts from both builds.