### PR TITLE
Build plugins in batch

### DIFF
--- a/internal/cmd/fetcher/main.go
+++ b/internal/cmd/fetcher/main.go
@@ -57,10 +57,7 @@ func postProcessCreatedPlugins(plugins []createdPlugin, rootDir string) error {
 			return err
 		}
 	}
-	if err := runPluginTests(plugins, rootDir); err != nil {
-		return err
-	}
-	return nil
+	return runPluginTests(plugins, rootDir)
 }
 
 // runGoModTidy runs 'go mod tidy' for plugins (like twirp-go) which don't use modules.


### PR DESCRIPTION
When fetch versions runs for gRPC or protoc plugins, we can optimize the build time significantly by building them in sequence instead of individually. Update fetch versions to build/test all new plugins together instead of individually.