### PR TITLE
Open GitHub issues on workflow failures

### DIFF
--- a/.github/automatic-workflow-issue-template.md
+++ b/.github/automatic-workflow-issue-template.md
@@ -1,0 +1,8 @@
+---
+title: Unexpected {{ workflow }} failure
+assignees: mfridman, pkwarren
+labels: bug
+---
+
+The automatic {{ workflow }} workflow failed, please investigate:
+{{ env.GITHUB_SERVER_URL }}/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }}/attempts/{{ env.GITHUB_RUN_ATTEMPT }}

--- a/.github/workflows/fetch_versions.yml
+++ b/.github/workflows/fetch_versions.yml
@@ -55,3 +55,15 @@ jobs:
           body: "New plugin versions found. Please review."
           assignees: mfridman, pkwarren
           token: ${{ steps.generate_token.outputs.token }}
+      - uses: dblock/create-a-github-issue@866beb009af3db457e82ca98efe474969a5ebce8
+        if: failure()
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_SERVER_URL: ${ github.server_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
+        with:
+          filename: .github/automatic-workflow-issue-template.md
+          update_existing: true
+          search_existing: open

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,18 @@ jobs:
         if: always()
         run: |
           rm -fv minisign.key
+      - uses: dblock/create-a-github-issue@866beb009af3db457e82ca98efe474969a5ebce8
+        if: failure()
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_SERVER_URL: ${ github.server_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
+        with:
+          filename: .github/automatic-workflow-issue-template.md
+          update_existing: true
+          search_existing: open
   upload:
     needs: release
     uses: ./.github/workflows/upload.yml

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -47,3 +47,15 @@ jobs:
           go run ./cmd/download-plugins downloads
       - name: Upload To Release Bucket
         run: gsutil rsync -r downloads gs://buf-plugins
+      - uses: dblock/create-a-github-issue@866beb009af3db457e82ca98efe474969a5ebce8
+        if: failure()
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_SERVER_URL: ${ github.server_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
+        with:
+          filename: .github/automatic-workflow-issue-template.md
+          update_existing: true
+          search_existing: open


### PR DESCRIPTION
Update fetch versions, release, and upload workflows to open GitHub issues on failure.