### PR TITLE
Automate bazel upgrades

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,6 +47,7 @@ linters:
     - depguard          # not needed
     - exhaustivestruct  # replaced by exhaustruct
     - funlen            # rely on code review to limit function length
+    - gochecknoglobals  # sometimes useful to declare constants
     - gocognit          # dubious "cognitive overhead" quantification
     - gofumpt           # prefer standard gofmt
     - goimports         # using gci
@@ -84,5 +85,4 @@ issues:
     - path: _test\.go
       linters:
         - dupword
-        - gochecknoglobals
         - gosec

--- a/cmd/download-plugins/main.go
+++ b/cmd/download-plugins/main.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 
 	"aead.dev/minisign"
-	"github.com/google/go-github/v50/github"
+	"github.com/google/go-github/v53/github"
 	"golang.org/x/mod/semver"
 
 	"github.com/bufbuild/plugins/internal/plugin"

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	aead.dev/minisign v0.2.0
 	github.com/bufbuild/buf v1.21.0
-	github.com/google/go-github/v50 v50.2.0
+	github.com/google/go-github/v53 v53.2.0
 	github.com/hashicorp/go-retryablehttp v0.7.4
 	github.com/sethvargo/go-envconfig v0.9.0
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/go-github/v50 v50.2.0 h1:j2FyongEHlO9nxXLc+LP3wuBSVU9mVxfpdYUexMpIfk=
-github.com/google/go-github/v50 v50.2.0/go.mod h1:VBY8FB6yPIjrtKhozXv4FQupxKLS6H4m6xFZlT43q8Q=
+github.com/google/go-github/v53 v53.2.0 h1:wvz3FyF53v4BK+AsnvCmeNhf8AkTaeh2SoYu/XUvTtI=
+github.com/google/go-github/v53 v53.2.0/go.mod h1:XhFRObz+m/l+UCm9b7KSIC3lT3NWSXGt7mOsAWEloao=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=

--- a/internal/cmd/release/main.go
+++ b/internal/cmd/release/main.go
@@ -22,7 +22,7 @@ import (
 
 	"aead.dev/minisign"
 	"github.com/bufbuild/buf/private/bufpkg/bufplugin/bufpluginref"
-	"github.com/google/go-github/v50/github"
+	"github.com/google/go-github/v53/github"
 	"golang.org/x/mod/semver"
 
 	"github.com/bufbuild/plugins/internal/plugin"

--- a/internal/fetchclient/fetchclient.go
+++ b/internal/fetchclient/fetchclient.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/google/go-github/v50/github"
+	"github.com/google/go-github/v53/github"
 	"github.com/hashicorp/go-retryablehttp"
 	"golang.org/x/mod/semver"
 	"golang.org/x/oauth2"

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -253,8 +253,8 @@ func ParsePluginsEnvVar(pluginsEnv string) ([]IncludePlugin, error) {
 }
 
 // getLatestPluginVersionsByName returns a map with keys set to plugin.Name and values set to the latest semver version for the plugin.
-// For example, if plugins contains buf.build/library/connect-web v0.1.1, v0.2.0, and v0.2.1,
-// the returned map will contain: {"buf.build/library/connect-web": "v0.2.1"}.
+// For example, if plugins contains buf.build/bufbuild/connect-web v0.1.1, v0.2.0, and v0.2.1,
+// the returned map will contain: {"buf.build/bufbuild/connect-web": "v0.2.1"}.
 func getLatestPluginVersionsByName(plugins []*Plugin) map[string]string {
 	latestVersions := make(map[string]string)
 	for _, plugin := range plugins {

--- a/internal/release/github.go
+++ b/internal/release/github.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"aead.dev/minisign"
-	"github.com/google/go-github/v50/github"
+	"github.com/google/go-github/v53/github"
 	"github.com/hashicorp/go-retryablehttp"
 	"golang.org/x/oauth2"
 )


### PR DESCRIPTION
Now that we have a Dockerfile.bazel that is kept up to date with dependabot, we can automate upgrades for packages that use Bazel.