### PR TITLE
Update to latest debian stable release

### DIFF
--- a/.github/docker/Dockerfile.debian
+++ b/.github/docker/Dockerfile.debian
@@ -1,3 +1,3 @@
-FROM debian:bullseye-20230612
+FROM debian:bookworm-20230612
 
 CMD echo this is a dummy file used to automate dependency upgrades for plugins

--- a/.github/docker/Dockerfile.golang
+++ b/.github/docker/Dockerfile.golang
@@ -1,3 +1,3 @@
-FROM golang:1.20.5-bullseye
+FROM golang:1.20.5-bookworm
 
 CMD echo this is a dummy file used to automate dependency upgrades for plugins


### PR DESCRIPTION
Debian 12 (bookworm) is now stable. We should update our builds to start using this going forward.