### PR TITLE
Add kotlin-stdlib in addition to jdk8 variant v3

### DIFF
--- a/plugins/protocolbuffers/kotlin/v22.2/buf.plugin.yaml
+++ b/plugins/protocolbuffers/kotlin/v22.2/buf.plugin.yaml
@@ -16,6 +16,7 @@ registry:
         version: 1.8.10
     deps:
       - com.google.protobuf:protobuf-kotlin:3.22.2
+      - org.jetbrains.kotlin:kotlin-stdlib:1.8.10
       - org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.10
     additional_runtimes:
       - name: lite

--- a/plugins/protocolbuffers/kotlin/v22.3/buf.plugin.yaml
+++ b/plugins/protocolbuffers/kotlin/v22.3/buf.plugin.yaml
@@ -16,6 +16,7 @@ registry:
         version: 1.8.10
     deps:
       - com.google.protobuf:protobuf-kotlin:3.22.3
+      - org.jetbrains.kotlin:kotlin-stdlib:1.8.10
       - org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.10
     additional_runtimes:
       - name: lite


### PR DESCRIPTION
We should ensure that we pull in both kotlin-stdlib AND kotlin-stdlib-jdk8 to ensure that consistent versions are used with the dependencies and the compiler. Without this, it is possible that protobuf-kotlin's dependency version kotlin-stdlib 1.6.0 is used instead.

Breaking this change into multiple PRs as these plugins take a long time to build.