### PR TITLE
Revert upgrade to latest Debian LTS

### DIFF
--- a/.github/docker/Dockerfile.debian
+++ b/.github/docker/Dockerfile.debian
@@ -1,3 +1,3 @@
-FROM debian:bookworm-20230703
+FROM debian:bullseye-20230703
 
 CMD echo this is a dummy file used to automate dependency upgrades for plugins

--- a/.github/docker/Dockerfile.golang
+++ b/.github/docker/Dockerfile.golang
@@ -1,3 +1,3 @@
-FROM golang:1.20.5-bookworm
+FROM golang:1.20.5-bullseye
 
 CMD echo this is a dummy file used to automate dependency upgrades for plugins


### PR DESCRIPTION
Seeing build errors from protoc plugins with the latest Debian version release. Try reverting back to bullseye to fix.

Hoping this will resolve #637.