### PR TITLE
Update connect-kotlin and grpc-kotlin deps

### DIFF
--- a/plugins/bufbuild/connect-kotlin/v0.1.8/buf.plugin.yaml
+++ b/plugins/bufbuild/connect-kotlin/v0.1.8/buf.plugin.yaml
@@ -4,6 +4,7 @@ plugin_version: v0.1.8
 source_url: https://github.com/bufbuild/connect-kotlin
 description: Idiomatic gRPC & Connect RPCs for Kotlin.
 deps:
+  # v23.4 revision updated 20230724
   - plugin: buf.build/protocolbuffers/kotlin:v23.4
 output_languages:
   - kotlin

--- a/plugins/grpc/kotlin/v1.3.0/buf.plugin.yaml
+++ b/plugins/grpc/kotlin/v1.3.0/buf.plugin.yaml
@@ -4,8 +4,8 @@ plugin_version: v1.3.0
 source_url: https://github.com/grpc/grpc-kotlin
 description: Generates Kotlin client and server stubs for the gRPC framework.
 deps:
-  - plugin: buf.build/grpc/java:v1.54.1
-  - plugin: buf.build/protocolbuffers/kotlin:v22.3
+  - plugin: buf.build/grpc/java:v1.56.1
+  - plugin: buf.build/protocolbuffers/kotlin:v23.4
 output_languages:
   - kotlin
 spdx_license_id: Apache-2.0


### PR DESCRIPTION
Update plugin dependencies for connect-kotlin and grpc-kotlin to pull in the latest version of the protocolbuffers/kotlin v23.4 plugin (which contains a patch for Kotlin package names).