### PR TITLE
Added cludden/protoc-gen-go-temporal

### DIFF
--- a/plugins/community/cludden-temporal-go/source.yaml
+++ b/plugins/community/cludden-temporal-go/source.yaml
@@ -1,0 +1,5 @@
+source:
+  github:
+    owner: cludden
+    repository: protoc-gen-go-temporal
+

--- a/plugins/community/cludden-temporal-go/v1.0.0-beta3/.dockerignore
+++ b/plugins/community/cludden-temporal-go/v1.0.0-beta3/.dockerignore
@@ -1,0 +1,2 @@
+*
+!Dockerfile

--- a/plugins/community/cludden-temporal-go/v1.0.0-beta3/Dockerfile
+++ b/plugins/community/cludden-temporal-go/v1.0.0-beta3/Dockerfile
@@ -1,0 +1,11 @@
+# syntax=docker/dockerfile:1.4
+FROM golang:1.20.3-bullseye AS build
+RUN --mount=type=cache,target=/go/pkg/mod \
+    CGO_ENABLED=0 \
+    go install -ldflags="-s -w" -trimpath github.com/cludden/protoc-gen-go-temporal/cmd/protoc-gen-go_temporal@v1.0.0-beta.3
+
+FROM scratch
+COPY --from=build --link --chown=root:root /etc/passwd /etc/passwd
+COPY --from=build --link --chown=root:root /go/bin/protoc-gen-go_temporal .
+USER nobody
+ENTRYPOINT [ "/protoc-gen-go_temporal" ]

--- a/plugins/community/cludden-temporal-go/v1.0.0-beta3/buf.plugin.yaml
+++ b/plugins/community/cludden-temporal-go/v1.0.0-beta3/buf.plugin.yaml
@@ -1,0 +1,9 @@
+version: v1
+name: buf.build/cludden-temporal-go
+plugin_version: v1.0.0-beta3
+source_url: https://github.com/cludden/protoc-gen-go-temporal
+description: A protoc plugin for generating temporal clients and workers in Go from protobuf schemas.
+output_languages:
+  - go
+spdx_license_id: MIT
+license_url: https://github.com/cludden/protoc-gen-go-temporal/blob/main/LICENSE.md


### PR DESCRIPTION
I do not now if you update plugins manually or automatically. Anyway, to ease the task to add cludden/protoc-gen-go-temporal plugin I added a PR.

It's a great plugin that helps a lot with temporal workflows. Would appreaciate if you can add it to the community plugins.

This solves #694.