### PR TITLE
Disable fetcher for bufbuild/connect-go

### DIFF
--- a/plugins/bufbuild/connect-go/source.yaml
+++ b/plugins/bufbuild/connect-go/source.yaml
@@ -1,4 +1,7 @@
 source:
+  # Users are encouraged to use the https://buf.build/connectrpc/go plugin which supersedes
+  # https://buf.build/bufbuild/connect-go.
+  disabled: true 
   github:
     owner: bufbuild
     repository: connect-go


### PR DESCRIPTION
Disable fetching new versions for bufbuild/connect-go, this plugin is now being synced to connectrpc/go