### PR TITLE
Update grpc-gateway to latest Go version

### DIFF
--- a/plugins/grpc-ecosystem/gateway/v2.17.0/Dockerfile
+++ b/plugins/grpc-ecosystem/gateway/v2.17.0/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM golang:1.20.7-bullseye AS build
+FROM golang:1.21.0-bullseye AS build
 
 WORKDIR /tmp
 RUN git clone --depth 1 --branch v2.17.0 https://github.com/grpc-ecosystem/grpc-gateway.git
@@ -12,7 +12,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     go build -ldflags "-s -w" -trimpath
 
 FROM scratch
-COPY --from=build --link /etc/passwd /etc/passwd
-COPY --from=build --link --chown=root:root /tmp/grpc-gateway/protoc-gen-grpc-gateway .
+COPY --from=build --link --chown=root:root /etc/passwd /etc/passwd
+COPY --from=build --link /tmp/grpc-gateway/protoc-gen-grpc-gateway .
 USER nobody
 ENTRYPOINT [ "/protoc-gen-grpc-gateway" ]


### PR DESCRIPTION
Update to be consistent with openapiv2. The tests are working E2E locally with this change. Updated the COPY statements to be more consistent with our other go commands.