### PR TITLE
Update workflow to only sync last day updates

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -22,14 +22,6 @@ jobs:
         with:
           go-version: '1.21'
           check-latest: true
-      - name: Cache Plugins
-        id: cache-plugins
-        uses: actions/cache@v3
-        with:
-          path: downloads
-          key: ${{ runner.os }}-plugin-downloads-${{ hashFiles('**/plugin-releases.json') }}
-          restore-keys: |
-            ${{ runner.os }}-plugin-downloads
         # uses https://cloud.google.com/iam/docs/workload-identity-federation to
         # swap a GitHub OIDC token for GCP service account credentials, allowing
         # this workflow to manage the buf-plugins bucket
@@ -44,7 +36,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          go run ./cmd/download-plugins downloads
+          go run ./cmd/download-plugins -since 24h downloads
       - name: Upload To Release Bucket
         run: gsutil rsync -r downloads gs://buf-plugins
       - uses: dblock/create-a-github-issue@866beb009af3db457e82ca98efe474969a5ebce8


### PR DESCRIPTION
The total number of plugins are over 500+ (and the size to download them all is significant). Update the release workflow to only download plugins created/modified in the last 24h instead of all plugins since the beginning of time. This should greatly speed up the upload workflow for releases.