### PR TITLE
community/danielgtaylor-betterproto version 2.0.0b6 added

### DIFF
--- a/plugins/community/danielgtaylor-betterproto/v2.0.0b6/.dockerignore
+++ b/plugins/community/danielgtaylor-betterproto/v2.0.0b6/.dockerignore
@@ -1,0 +1,3 @@
+*
+!Dockerfile
+!requirements.txt

--- a/plugins/community/danielgtaylor-betterproto/v2.0.0b6/Dockerfile
+++ b/plugins/community/danielgtaylor-betterproto/v2.0.0b6/Dockerfile
@@ -1,0 +1,16 @@
+# syntax=docker/dockerfile:1.4
+FROM python:3.11.4-alpine3.18 AS build
+WORKDIR /app
+RUN python -mvenv /app
+ADD /requirements.txt requirements.txt
+RUN source ./bin/activate \
+ && pip install --no-cache-dir -r requirements.txt \
+ && pip uninstall --yes pip setuptools \
+ && rm -f requirements.txt bin/activate.fish bin/activate.csh bin/Activate.ps1
+
+FROM python:3.11.4-alpine3.18
+COPY --from=build --link /app /app
+USER nobody
+# Plugin uses os.makedirs - needs to run in a directory it can write to
+WORKDIR /tmp
+ENTRYPOINT [ "/app/bin/protoc-gen-python_betterproto" ]

--- a/plugins/community/danielgtaylor-betterproto/v2.0.0b6/buf.plugin.yaml
+++ b/plugins/community/danielgtaylor-betterproto/v2.0.0b6/buf.plugin.yaml
@@ -1,0 +1,9 @@
+version: v1
+name: buf.build/community/danielgtaylor-betterproto
+plugin_version: v2.0.0b6
+source_url: https://github.com/danielgtaylor/python-betterproto
+description: Better Protobuf / gRPC Support for Python.
+spdx_license_id: MIT
+license_url: https://github.com/danielgtaylor/python-betterproto/blob/v.2.0.0b6/LICENSE.md
+output_languages:
+  - python

--- a/plugins/community/danielgtaylor-betterproto/v2.0.0b6/requirements.txt
+++ b/plugins/community/danielgtaylor-betterproto/v2.0.0b6/requirements.txt
@@ -1,0 +1,16 @@
+betterproto==2.0.0b6
+black==23.3.0
+click==8.1.3
+grpclib==0.4.4
+h2==4.1.0
+hpack==4.0.0
+hyperframe==6.0.1
+Jinja2==3.1.2
+MarkupSafe==2.1.3
+multidict==6.0.4
+mypy-extensions==1.0.0
+packaging==23.1
+pathspec==0.11.1
+platformdirs==3.5.3
+protobuf==4.23.2
+stringcase==1.2.0


### PR DESCRIPTION
- buf currently supports only community/danielgtaylor-betterproto v1.2.5, which is from 05/2020
- the newly added version is from 06/2023 - it has a lot of fixes etc.

- the PR is a copy-paste of the v1.2.5. The only changes are `betterproto==2.0.0b6` in `requirements.txt` and `license_url` in `buf.plugin.yaml`