### PR TITLE
Update fetcher to skip pre-release versions

### DIFF
--- a/internal/cmd/fetcher/main.go
+++ b/internal/cmd/fetcher/main.go
@@ -172,7 +172,7 @@ func run(ctx context.Context, root string) ([]createdPlugin, error) {
 	created := make([]createdPlugin, 0, len(configs))
 	for _, config := range configs {
 		if config.Source.Disabled {
-			log.Printf("skipping source: %s\n", config.Filename)
+			log.Printf("skipping source: %s", config.Filename)
 			continue
 		}
 		newVersion := latestVersions[config.CacheKey()]
@@ -180,7 +180,7 @@ func run(ctx context.Context, root string) ([]createdPlugin, error) {
 			newVersion, err = client.Fetch(ctx, config)
 			if err != nil {
 				if errors.Is(err, fetchclient.ErrSemverPrerelease) {
-					log.Println(err)
+					log.Printf("skipping source: %s: %v", config.Filename, err)
 					continue
 				}
 				return nil, err

--- a/internal/cmd/fetcher/main.go
+++ b/internal/cmd/fetcher/main.go
@@ -179,6 +179,10 @@ func run(ctx context.Context, root string) ([]createdPlugin, error) {
 		if newVersion == "" {
 			newVersion, err = client.Fetch(ctx, config)
 			if err != nil {
+				if errors.Is(err, fetchclient.ErrSemverPreRelease) {
+					log.Println(err)
+					continue
+				}
 				return nil, err
 			}
 			latestVersions[config.CacheKey()] = newVersion

--- a/internal/cmd/fetcher/main.go
+++ b/internal/cmd/fetcher/main.go
@@ -179,7 +179,7 @@ func run(ctx context.Context, root string) ([]createdPlugin, error) {
 		if newVersion == "" {
 			newVersion, err = client.Fetch(ctx, config)
 			if err != nil {
-				if errors.Is(err, fetchclient.ErrSemverPreRelease) {
+				if errors.Is(err, fetchclient.ErrSemverPrerelease) {
 					log.Println(err)
 					continue
 				}

--- a/internal/fetchclient/fetchclient.go
+++ b/internal/fetchclient/fetchclient.go
@@ -29,8 +29,8 @@ const (
 )
 
 var (
-	// ErrSemverPreRelease is returned when a version is a pre-release.
-	ErrSemverPreRelease = errors.New("pre-release versions are not supported")
+	// ErrSemverPrerelease is returned when a version is a pre-release.
+	ErrSemverPrerelease = errors.New("pre-release versions are not supported")
 )
 
 // Client is a client used to fetch latest package version.
@@ -73,7 +73,7 @@ func (c *Client) Fetch(ctx context.Context, config *source.Config) (string, erro
 		return "", fmt.Errorf("%s: invalid semver: %s", config.Source.Name(), version)
 	}
 	if semver.Prerelease(version) != "" {
-		return "", fmt.Errorf("%s: %w: %s", config.Source.Name(), ErrSemverPreRelease, version)
+		return "", fmt.Errorf("%s: %w: %s", config.Source.Name(), ErrSemverPrerelease, version)
 	}
 	return version, nil
 }


### PR DESCRIPTION
Small fix to the fetcher to handle pre-release versions properly.

Fix #806

> 2023/09/13 10:43:30 skipping source: plugins/connectrpc/es/source.yaml: npm_registry: pre-release versions are not supported: v1.0.0-rc1
2023/09/13 10:43:30 finished running in: 0.79s

We handle the error gracefully and skip the version.