### PR TITLE
Update inputs for tibdex/github-app-token

### DIFF
--- a/.github/workflows/fetch_versions.yml
+++ b/.github/workflows/fetch_versions.yml
@@ -22,7 +22,6 @@ jobs:
         with:
           app_id: 249762
           private_key: ${{ secrets.TOKEN_EXCHANGE_GH_APP_PRIVATE_KEY }}
-          repository: ${{ github.repository }}
           permissions: >-
             {"contents": "write", "pull_requests": "write"}
       - name: Checkout repository code


### PR DESCRIPTION
The previous 'repository' input has been replaced with two new inputs, 'installation_retrieval_mode' and 'installation_retrieval_payload'. The defaults for these values are the same as the previous 'repository' input, so we can remove this to fix warnings with the fetch versions workflow.