### PR TITLE
Add a per-plugin cache

### DIFF
--- a/internal/cmd/dockerbuild/main.go
+++ b/internal/cmd/dockerbuild/main.go
@@ -1,23 +1,39 @@
 package main
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"flag"
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/bufbuild/buf/private/pkg/interrupt"
-
 	"github.com/bufbuild/plugins/internal/docker"
+	"golang.org/x/mod/semver"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/bufbuild/plugins/internal/plugin"
 )
 
-// dockerbuild is a helper program used to build plugins from Dockerfiles.
+// dockerbuild is a helper program used to build plugins from Dockerfiles in an optimized fashion.
+// It replaces some clunky (and non-parallel) jobs in the Makefile.
+// It knows about relationships between common containers (like protoc/grpc Bazel plugins),
+// which enables optimized builds which build common code first before binaries.
 // It also makes it easier to add new labels to images using existing code to parse buf.plugin.yaml.
+
+const (
+	// larger amount of parallelism lead to OOM errors in testing - clamp for now.
+	maxLimit = 8
+	// plugin group for all bazel builds (they are run serially on their own as they are very resource intensive).
+	bazelPluginGroup = "bazel"
+)
 
 func main() {
 	var (
@@ -26,30 +42,127 @@ func main() {
 		cacheDir = flag.String("cache-dir", "", "Cache directory")
 	)
 	flag.Parse()
-	if err := run(*dir, *org, *cacheDir, flag.Args()); err != nil {
+	cmd := &command{
+		pluginsDir:      *dir,
+		dockerOrg:       *org,
+		cacheDir:        *cacheDir,
+		dockerBuildArgs: flag.Args(),
+	}
+	if err := cmd.run(flag.Args()); err != nil {
 		log.Fatalf("failed to build: %v", err)
 	}
 }
 
-func run(basedir string, dockerOrg string, cacheDir string, args []string) error {
+type command struct {
+	// pluginsDir specifies the directory where plugins are found (typically the root of the bufbuild/plugins repo).
+	pluginsDir string
+	// dockerOrg is the Docker organization to use in the tagged image.
+	dockerOrg string
+	// cacheDir is an optional setting to the root where Docker buildx local caches should be kept.
+	cacheDir string
+	// dockerBuildArgs contains additional arguments to pass to the Docker build.
+	dockerBuildArgs []string
+}
+
+func (c *command) run(args []string) error {
 	// Catch ctrl+c to kill the build process
 	ctx, cancel := interrupt.WithCancel(context.Background())
 	defer cancel()
-	plugins, err := plugin.FindAll(basedir)
+	allPlugins, err := plugin.FindAll(c.pluginsDir)
 	if err != nil {
 		return err
 	}
-	includedPlugins, err := plugin.FilterByPluginsEnv(plugins, os.Getenv("PLUGINS"))
+	includedPlugins, err := plugin.FilterByPluginsEnv(allPlugins, os.Getenv("PLUGINS"))
 	if err != nil {
 		return err
 	}
 	if len(includedPlugins) == 0 {
 		return nil // nothing to build
 	}
-	for _, pluginToBuild := range includedPlugins {
+	pluginGroups, err := getPluginGroups(includedPlugins)
+	if err != nil {
+		return err
+	}
+	// Build bazel plugins on their own as they are very resource intensive.
+	if bazelPlugins, ok := pluginGroups[bazelPluginGroup]; ok {
+		if err := c.buildPluginGroup(ctx, bazelPluginGroup, bazelPlugins); err != nil {
+			return err
+		}
+		delete(pluginGroups, bazelPluginGroup)
+		if len(pluginGroups) == 0 {
+			return nil
+		}
+	}
+	limit := runtime.GOMAXPROCS(0)
+	if limit > maxLimit {
+		limit = maxLimit
+	}
+	var eg *errgroup.Group
+	eg, ctx = errgroup.WithContext(ctx)
+	eg.SetLimit(limit)
+	for pluginGroup, plugins := range pluginGroups {
+		pluginGroup := pluginGroup
+		plugins := plugins
+		if len(plugins) > 1 {
+			// Sort plugins to build first by version, then by name.
+			// This ensures the best use of the Docker build cache for expensive builds like protoc/grpc plugins.
+			slices.SortFunc(plugins, func(a, b *plugin.Plugin) int {
+				if v := semver.Compare(a.PluginVersion, b.PluginVersion); v != 0 {
+					return v
+				}
+				return cmp.Compare(a.Name, b.Name)
+			})
+		}
+		eg.Go(func() error {
+			return c.buildPluginGroup(ctx, pluginGroup, plugins)
+		})
+	}
+	return eg.Wait()
+}
+
+func getPluginGroups(plugins []*plugin.Plugin) (map[string][]*plugin.Plugin, error) {
+	pluginGroups := make(map[string][]*plugin.Plugin)
+	for _, pluginToBuild := range plugins {
+		var pluginKey string
+		identity := pluginToBuild.Identity
+		// Group grpc/protobuf builds together so one finishes to completion before running additional jobs.
+		// This is important because builds can share the Docker cache to optimize longer Bazel builds.
+		switch owner := identity.Owner(); owner {
+		case "grpc":
+			switch identity.Plugin() {
+			case "cpp", "csharp", "objc", "php", "python", "ruby":
+				pluginKey = bazelPluginGroup
+			}
+		case "protocolbuffers":
+			switch identity.Plugin() {
+			case "cpp", "csharp", "java", "kotlin", "objc", "php", "pyi", "python", "ruby", "rust":
+				pluginKey = bazelPluginGroup
+			}
+		default:
+			// Assume everything else can be built independently
+			pluginKey = identity.IdentityString()
+		}
+		pluginGroups[pluginKey] = append(pluginGroups[pluginKey], pluginToBuild)
+	}
+	return pluginGroups, nil
+}
+
+func (c *command) buildPluginGroup(ctx context.Context, pluginGroup string, plugins []*plugin.Plugin) error {
+	for _, pluginToBuild := range plugins {
+		pluginIdentity := pluginToBuild.Identity
+		var pluginCacheDir string
+		// If cache is enabled, create a unique cache directory per group of plugins.
+		// This enables bazel builds to share a common cache while allowing parallel builds.
+		if c.cacheDir != "" {
+			if pluginGroup == bazelPluginGroup {
+				pluginCacheDir = filepath.Join(c.cacheDir, pluginGroup, pluginIdentity.Owner(), pluginToBuild.PluginVersion)
+			} else {
+				pluginCacheDir = filepath.Join(c.cacheDir, pluginIdentity.Owner(), pluginIdentity.Plugin(), pluginToBuild.PluginVersion)
+			}
+		}
 		log.Println("building:", pluginToBuild.Name, pluginToBuild.PluginVersion)
 		start := time.Now()
-		output, err := docker.Build(ctx, pluginToBuild, dockerOrg, cacheDir, args)
+		output, err := docker.Build(ctx, pluginToBuild, c.dockerOrg, pluginCacheDir, c.dockerBuildArgs)
 		if err != nil {
 			if errors.Is(err, context.Canceled) || strings.Contains(err.Error(), "signal: killed") {
 				return err

--- a/internal/cmd/dockerbuild/main.go
+++ b/internal/cmd/dockerbuild/main.go
@@ -48,7 +48,7 @@ func main() {
 		cacheDir:        *cacheDir,
 		dockerBuildArgs: flag.Args(),
 	}
-	if err := cmd.run(flag.Args()); err != nil {
+	if err := cmd.run(); err != nil {
 		log.Fatalf("failed to build: %v", err)
 	}
 }
@@ -64,7 +64,7 @@ type command struct {
 	dockerBuildArgs []string
 }
 
-func (c *command) run(args []string) error {
+func (c *command) run() error {
 	// Catch ctrl+c to kill the build process
 	ctx, cancel := interrupt.WithCancel(context.Background())
 	defer cancel()

--- a/internal/cmd/dockerbuild/main.go
+++ b/internal/cmd/dockerbuild/main.go
@@ -15,10 +15,10 @@ import (
 	"time"
 
 	"github.com/bufbuild/buf/private/pkg/interrupt"
-	"github.com/bufbuild/plugins/internal/docker"
 	"golang.org/x/mod/semver"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/bufbuild/plugins/internal/docker"
 	"github.com/bufbuild/plugins/internal/plugin"
 )
 
@@ -79,10 +79,7 @@ func (c *command) run() error {
 	if len(includedPlugins) == 0 {
 		return nil // nothing to build
 	}
-	pluginGroups, err := getPluginGroups(includedPlugins)
-	if err != nil {
-		return err
-	}
+	pluginGroups := getPluginGroups(includedPlugins)
 	// Build bazel plugins on their own as they are very resource intensive.
 	if bazelPlugins, ok := pluginGroups[bazelPluginGroup]; ok {
 		delete(pluginGroups, bazelPluginGroup)
@@ -118,7 +115,7 @@ func (c *command) run() error {
 	return eg.Wait()
 }
 
-func getPluginGroups(plugins []*plugin.Plugin) (map[string][]*plugin.Plugin, error) {
+func getPluginGroups(plugins []*plugin.Plugin) map[string][]*plugin.Plugin {
 	pluginGroups := make(map[string][]*plugin.Plugin)
 	for _, pluginToBuild := range plugins {
 		var pluginKey string
@@ -142,7 +139,7 @@ func getPluginGroups(plugins []*plugin.Plugin) (map[string][]*plugin.Plugin, err
 		}
 		pluginGroups[pluginKey] = append(pluginGroups[pluginKey], pluginToBuild)
 	}
-	return pluginGroups, nil
+	return pluginGroups
 }
 
 func (c *command) buildPluginGroup(ctx context.Context, pluginGroup string, plugins []*plugin.Plugin) error {

--- a/internal/docker/build.go
+++ b/internal/docker/build.go
@@ -8,8 +8,6 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/bufbuild/buf/private/bufpkg/bufplugin/bufpluginref"
-
 	"github.com/bufbuild/plugins/internal/plugin"
 )
 
@@ -27,14 +25,8 @@ func Build(
 	if err != nil {
 		return nil, err
 	}
-	identity, err := bufpluginref.PluginIdentityForString(plugin.Name)
-	if err != nil {
-		return nil, err
-	}
-	imageName, err := ImageName(plugin, dockerOrg)
-	if err != nil {
-		return nil, err
-	}
+	identity := plugin.Identity
+	imageName := ImageName(plugin, dockerOrg)
 	commonArgs := []string{
 		"buildx",
 		"build",

--- a/internal/docker/name.go
+++ b/internal/docker/name.go
@@ -3,16 +3,11 @@ package docker
 import (
 	"fmt"
 
-	"github.com/bufbuild/buf/private/bufpkg/bufplugin/bufpluginref"
-
 	"github.com/bufbuild/plugins/internal/plugin"
 )
 
 // ImageName returns the name of the plugin's tagged image in the given organization.
-func ImageName(plugin *plugin.Plugin, org string) (string, error) {
-	identity, err := bufpluginref.PluginIdentityForString(plugin.Name)
-	if err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("%s/plugins-%s-%s:%s", org, identity.Owner(), identity.Plugin(), plugin.PluginVersion), nil
+func ImageName(plugin *plugin.Plugin, org string) string {
+	identity := plugin.Identity
+	return fmt.Sprintf("%s/plugins-%s-%s:%s", org, identity.Owner(), identity.Plugin(), plugin.PluginVersion)
 }

--- a/internal/docker/push.go
+++ b/internal/docker/push.go
@@ -14,10 +14,7 @@ func Push(ctx context.Context, plugin *plugin.Plugin, dockerOrg string) ([]byte,
 	if err != nil {
 		return nil, err
 	}
-	imageName, err := ImageName(plugin, dockerOrg)
-	if err != nil {
-		return nil, err
-	}
+	imageName := ImageName(plugin, dockerOrg)
 	cmd := exec.CommandContext(
 		ctx,
 		dockerCmd,

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -13,6 +13,7 @@ import (
 	"unicode"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufplugin/bufpluginconfig"
+	"github.com/bufbuild/buf/private/bufpkg/bufplugin/bufpluginref"
 	"github.com/bufbuild/buf/private/pkg/encoding"
 	"github.com/sethvargo/go-envconfig"
 	"golang.org/x/mod/semver"
@@ -24,6 +25,8 @@ type Plugin struct {
 	Relpath string `yaml:"-"`
 	// Parsed external yaml config
 	bufpluginconfig.ExternalConfig `yaml:"-"`
+	// Plugin identity (parsed from ExternalConfig.Name).
+	Identity bufpluginref.PluginIdentity `yaml:"-"`
 }
 
 func (p *Plugin) String() string {
@@ -152,6 +155,10 @@ func Load(path string, basedir string) (*Plugin, error) {
 	}
 	plugin.Relpath = filepath.ToSlash(plugin.Relpath)
 	if err := encoding.UnmarshalJSONOrYAMLStrict(contents, &plugin.ExternalConfig); err != nil {
+		return nil, err
+	}
+	plugin.Identity, err = bufpluginref.PluginIdentityForString(plugin.Name)
+	if err != nil {
 		return nil, err
 	}
 	return &plugin, nil


### PR DESCRIPTION
It appears than non-bazel builds aren't getting use of the local cache as well as other builds. Update the dockerbuild command to create unique cache directories per plugin and version, and reinstate the ability to build images in parallel.