### PR TITLE
Re-enable the buf-setup-action in CI workflows

### DIFF
--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -38,11 +38,9 @@ jobs:
         go-version: '1.21'
         check-latest: true
     - name: Install buf cli
-      run: |
-        go install github.com/bufbuild/buf/cmd/buf@main
-      # uses: bufbuild/buf-setup-action@v1
-      # with:
-      #   github_token: ${{ github.token }}
+      uses: bufbuild/buf-setup-action@v1
+      with:
+        github_token: ${{ github.token }}
     - name: Set up QEMU
       uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3
     - name: Set up Docker Buildx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,11 +71,9 @@ jobs:
           echo "PLUGINS=${val}" >> $GITHUB_ENV
         fi
     - name: Install buf cli
-      run: |
-        go install github.com/bufbuild/buf/cmd/buf@main
-      # uses: bufbuild/buf-setup-action@v1
-      # with:
-      #   github_token: ${{ github.token }}
+      uses: bufbuild/buf-setup-action@v1
+      with:
+        github_token: ${{ github.token }}
     - name: Set up QEMU
       uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3
     - name: Set up Docker Buildx

--- a/.github/workflows/fetch_versions.yml
+++ b/.github/workflows/fetch_versions.yml
@@ -34,11 +34,9 @@ jobs:
           go-version: '1.21'
           check-latest: true
       - name: Install buf cli
-        run: |
-          go install github.com/bufbuild/buf/cmd/buf@main
-        # uses: bufbuild/buf-setup-action@v1
-        # with:
-        #   github_token: ${{ github.token }}
+        uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ github.token }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3
       - name: Set up Docker Buildx

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -65,11 +65,9 @@ jobs:
           echo "PLUGINS=${val}" >> $GITHUB_ENV
         fi
     - name: Install buf cli
-      run: |
-        go install github.com/bufbuild/buf/cmd/buf@main
-      # uses: bufbuild/buf-setup-action@v1
-      # with:
-      #   github_token: ${{ github.token }}
+      uses: bufbuild/buf-setup-action@v1
+      with:
+        github_token: ${{ github.token }}
     - name: Set up QEMU
       uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3
     - name: Set up Docker Buildx


### PR DESCRIPTION
The changes required for integration guides landed in v1.27.2, so we can move back to the standard buf-setup-action in CI builds.