### PR TITLE
Add apple/swift v1.25.1

### DIFF
--- a/plugins/apple/swift/v1.25.1/.dockerignore
+++ b/plugins/apple/swift/v1.25.1/.dockerignore
@@ -1,0 +1,3 @@
+*
+!Dockerfile
+!extramoduleimports.patch

--- a/plugins/apple/swift/v1.25.1/Dockerfile
+++ b/plugins/apple/swift/v1.25.1/Dockerfile
@@ -1,0 +1,14 @@
+# syntax=docker/dockerfile:1.4
+FROM swift:5.9.1-focal AS build
+
+COPY extramoduleimports.patch /app/extramoduleimports.patch
+WORKDIR /app
+RUN git clone --depth 1 --branch 1.25.1 https://github.com/apple/swift-protobuf --recursive
+WORKDIR /app/swift-protobuf
+RUN git apply /app/extramoduleimports.patch
+RUN swift build -c release --static-swift-stdlib -Xlinker -s
+
+FROM gcr.io/distroless/cc-debian11
+COPY --from=build --link /app/swift-protobuf/.build/release/protoc-gen-swift .
+USER nobody
+ENTRYPOINT [ "/protoc-gen-swift" ]

--- a/plugins/apple/swift/v1.25.1/buf.plugin.yaml
+++ b/plugins/apple/swift/v1.25.1/buf.plugin.yaml
@@ -1,0 +1,21 @@
+version: v1
+name: buf.build/apple/swift
+plugin_version: v1.25.1
+source_url: https://github.com/apple/swift-protobuf
+integration_guide_url: https://github.com/apple/swift-protobuf#getting-started
+description: Base types for Swift. Generates message and enum types.
+output_languages:
+  - swift
+registry:
+  swift:
+    deps:
+      - source: https://github.com/apple/swift-protobuf.git
+        package: swift-protobuf
+        swift_versions: [ ".v5" ]
+        products: [ SwiftProtobuf ]
+        version: 1.25.1
+  opts:
+    - Visibility=Public
+    - FileNaming=PathToUnderscores
+spdx_license_id: Apache-2.0
+license_url: https://github.com/apple/swift-protobuf/blob/1.25.1/LICENSE.txt

--- a/plugins/apple/swift/v1.25.1/extramoduleimports.patch
+++ b/plugins/apple/swift/v1.25.1/extramoduleimports.patch
@@ -1,0 +1,58 @@
+diff --git a/Sources/protoc-gen-swift/FileGenerator.swift b/Sources/protoc-gen-swift/FileGenerator.swift
+index 90fd06a6..93460574 100644
+--- a/Sources/protoc-gen-swift/FileGenerator.swift
++++ b/Sources/protoc-gen-swift/FileGenerator.swift
+@@ -121,6 +121,13 @@ class FileGenerator {
+                 p.print("\(visibilityAnnotation)import \(i)\n")
+             }
+         }
++        let neededCustomImports = generatorOptions.extraModuleImports
++        if !neededCustomImports.isEmpty {
++            p.print()
++            for i in neededCustomImports {
++                p.print("import \(i)\n")
++            }
++        }
+ 
+         p.print("\n")
+         generateVersionCheck(printer: &p)
+diff --git a/Sources/protoc-gen-swift/GeneratorOptions.swift b/Sources/protoc-gen-swift/GeneratorOptions.swift
+index 7b7b4bad..969dc0c1 100644
+--- a/Sources/protoc-gen-swift/GeneratorOptions.swift
++++ b/Sources/protoc-gen-swift/GeneratorOptions.swift
+@@ -53,6 +53,7 @@ class GeneratorOptions {
+   let protoToModuleMappings: ProtoFileToModuleMappings
+   let visibility: Visibility
+   let implementationOnlyImports: Bool
++  let extraModuleImports: [String]
+ 
+   /// A string snippet to insert for the visibility
+   let visibilitySourceSnippet: String
+@@ -63,6 +64,7 @@ class GeneratorOptions {
+     var visibility: Visibility = .internal
+     var swiftProtobufModuleName: String? = nil
+     var implementationOnlyImports: Bool = false
++    var externalModuleImports: [String] = []
+ 
+     for pair in parameter.parsedPairs {
+       switch pair.key {
+@@ -100,6 +102,12 @@ class GeneratorOptions {
+           throw GenerationError.invalidParameterValue(name: pair.key,
+                                                       value: pair.value)
+         }
++      case "ExtraModuleImports":
++        if !pair.value.isEmpty {
++            externalModuleImports.append(pair.value)
++        } else {
++          throw GenerationError.invalidParameterValue(name: pair.key, value: pair.value)
++        }
+       default:
+         throw GenerationError.unknownParameter(name: pair.key)
+       }
+@@ -130,5 +138,6 @@ class GeneratorOptions {
+     }
+ 
+     self.implementationOnlyImports = implementationOnlyImports
++    self.extraModuleImports = externalModuleImports
+   }
+ }

--- a/tests/testdata/buf.build/apple/swift/v1.25.1/eliza/plugin.sum
+++ b/tests/testdata/buf.build/apple/swift/v1.25.1/eliza/plugin.sum
@@ -1,0 +1,1 @@
+h1:ffGsj903OkejaJHBJ9J0lmZkRiA58mar/OznBW1O9Wo=

--- a/tests/testdata/buf.build/apple/swift/v1.25.1/petapis/plugin.sum
+++ b/tests/testdata/buf.build/apple/swift/v1.25.1/petapis/plugin.sum
@@ -1,0 +1,1 @@
+h1:OFSRkh+P/PzCpshzAoe7dS9I6VjMZI2KR9v8xRP5lso=


### PR DESCRIPTION
This PR makes a slight update to the patch because of a merge conflict due to upstream changes.

Here's a diff between the current patch and the [v1.24.0 patch](https://github.com/bufbuild/plugins/blob/8da3b86ff10619c1beb0a6cea9cc59a819be3be1/plugins/apple/swift/v1.24.0/extramoduleimports.patch#L1)

```diff
--- A/extramoduleimports-3.patch
+++ B/extramoduleimports-4.patch
@@ -17,10 +17,10 @@
          p.print("\n")
          generateVersionCheck(printer: &p)
 diff --git a/Sources/protoc-gen-swift/GeneratorOptions.swift b/Sources/protoc-gen-swift/GeneratorOptions.swift
+index 7b7b4bad..969dc0c1 100644
-index 69ecdb86..e0f2e26e 100644
 --- a/Sources/protoc-gen-swift/GeneratorOptions.swift
 +++ b/Sources/protoc-gen-swift/GeneratorOptions.swift
+@@ -53,6 +53,7 @@ class GeneratorOptions {
-@@ -50,6 +50,7 @@ class GeneratorOptions {
    let protoToModuleMappings: ProtoFileToModuleMappings
    let visibility: Visibility
    let implementationOnlyImports: Bool
@@ -28,17 +28,17 @@
  
    /// A string snippet to insert for the visibility
    let visibilitySourceSnippet: String
+@@ -63,6 +64,7 @@ class GeneratorOptions {
-@@ -60,6 +61,7 @@ class GeneratorOptions {
      var visibility: Visibility = .internal
      var swiftProtobufModuleName: String? = nil
      var implementationOnlyImports: Bool = false
 +    var externalModuleImports: [String] = []
  
+     for pair in parameter.parsedPairs {
-     for pair in parseParameter(string:parameter) {
        switch pair.key {
+@@ -100,6 +102,12 @@ class GeneratorOptions {
+           throw GenerationError.invalidParameterValue(name: pair.key,
+                                                       value: pair.value)
-@@ -94,6 +96,12 @@ class GeneratorOptions {
-         if let value = Bool(pair.value) {
-           implementationOnlyImports = value
          }
 +      case "ExtraModuleImports":
 +        if !pair.value.isEmpty {
@@ -49,7 +49,7 @@
        default:
          throw GenerationError.unknownParameter(name: pair.key)
        }
+@@ -130,5 +138,6 @@ class GeneratorOptions {
-@@ -122,5 +130,6 @@ class GeneratorOptions {
      }
  
      self.implementationOnlyImports = implementationOnlyImports
```