### PR TITLE
Only rebuild plugins if changed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,10 +32,10 @@ all: build
 
 .PHONY: build
 build:
-	docker buildx inspect "$(DOCKER_BUILDER)" 2> /dev/null || docker buildx create --use --bootstrap --name="$(DOCKER_BUILDER)"
+	docker buildx inspect "$(DOCKER_BUILDER)" 2> /dev/null || docker buildx create --use --bootstrap --name="$(DOCKER_BUILDER)" > /dev/null
 	go run ./internal/cmd/dockerbuild -cache-dir "$(DOCKER_CACHE_DIR)" -org "$(DOCKER_ORG)" -- $(DOCKER_BUILD_EXTRA_ARGS) || \
 		(docker buildx rm "$(DOCKER_BUILDER)"; exit 1)
-	docker buildx rm "$(DOCKER_BUILDER)"
+	docker buildx rm "$(DOCKER_BUILDER)" > /dev/null
 
 .PHONY: dockerpush
 dockerpush:

--- a/internal/docker/push.go
+++ b/internal/docker/push.go
@@ -10,14 +10,10 @@ import (
 // Push pushes a docker image for the given plugin to the Docker organization.
 // It assumes it has already been built in a previous step.
 func Push(ctx context.Context, plugin *plugin.Plugin, dockerOrg string) ([]byte, error) {
-	dockerCmd, err := exec.LookPath("docker")
-	if err != nil {
-		return nil, err
-	}
 	imageName := ImageName(plugin, dockerOrg)
 	cmd := exec.CommandContext(
 		ctx,
-		dockerCmd,
+		"docker",
 		"push",
 		imageName,
 	)

--- a/tests/plugins_test.go
+++ b/tests/plugins_test.go
@@ -65,6 +65,7 @@ func TestGeneration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping code generation test")
 	}
+	ctx := context.Background()
 	allowEmpty, _ := strconv.ParseBool(os.Getenv("ALLOW_EMPTY_PLUGIN_SUM"))
 	testPluginWithImage := func(t *testing.T, pluginMeta *plugin.Plugin, image string) {
 		t.Helper()
@@ -78,7 +79,7 @@ func TestGeneration(t *testing.T) {
 			require.NoError(t, os.MkdirAll(pluginDir, 0o755))
 			require.NoError(t, createBufGenYaml(t, pluginDir, pluginMeta))
 			require.NoError(t, createProtocGenPlugin(t, pluginDir, pluginMeta))
-			bufCmd := exec.Command("buf", "generate", filepath.Join(imageDir, image+".bin.gz"))
+			bufCmd := exec.CommandContext(ctx, "buf", "generate", filepath.Join(imageDir, image+".bin.gz"))
 			bufCmd.Dir = pluginDir
 			output, err := bufCmd.CombinedOutput()
 			require.NoErrorf(t, err, "buf generate failed - output: %s", string(output))


### PR DESCRIPTION
Update the dockerbuild command to add a label containing the git revision of the plugin's directory (if there are no changes to the working directory of the plugin). If we determine that an image exists for the same revision of the plugin, skip costly rebuilds.

Additionally, update commands to use exec.CommandContext consistently and stop calling exec.LookPath as the exec package does this automatically for us if the command doesn't contain path separators.