### PR TITLE
Add python registry config for grpc/python v1.59.2

### DIFF
--- a/plugins/grpc/python/v1.59.2/buf.plugin.yaml
+++ b/plugins/grpc/python/v1.59.2/buf.plugin.yaml
@@ -9,3 +9,11 @@ output_languages:
   - python
 spdx_license_id: Apache-2.0
 license_url: https://github.com/grpc/grpc/blob/v1.59.2/LICENSE
+registry:
+  python:
+    package_type: "runtime"
+    # https://github.com/grpc/grpc/tree/v1.59.2/src/python/grpcio#supported-python-versions
+    requires_python: ">=3.7"
+    deps:
+      # https://pypi.org/project/grpcio/
+      - "grpcio"


### PR DESCRIPTION
Missed this version, and added it to grpc v1.59.1. Oops.