### PR TITLE
Start tracking distroless image updates

### DIFF
--- a/.github/docker/Dockerfile.debian
+++ b/.github/docker/Dockerfile.debian
@@ -1,3 +1,3 @@
-FROM debian:bullseye-20231120
+FROM debian:bookworm-20231120
 
 CMD echo this is a dummy file used to automate dependency upgrades for plugins

--- a/.github/docker/Dockerfile.distroless-base-debian
+++ b/.github/docker/Dockerfile.distroless-base-debian
@@ -1,0 +1,3 @@
+FROM gcr.io/distroless/base-debian12:latest@sha256:1dfdb5ed7d9a66dcfc90135b25a46c25a85cf719b619b40c249a2445b9d055f5
+
+CMD echo this is a dummy file used to automate dependency upgrades for plugins

--- a/.github/docker/Dockerfile.distroless-cc-debian
+++ b/.github/docker/Dockerfile.distroless-cc-debian
@@ -1,0 +1,3 @@
+FROM gcr.io/distroless/cc-debian12:latest@sha256:a9056d2232d16e3772bec3ef36b93a5ea9ef6ad4b4ed407631e534b85832cf40
+
+CMD echo this is a dummy file used to automate dependency upgrades for plugins

--- a/.github/docker/Dockerfile.distroless-java-debian
+++ b/.github/docker/Dockerfile.distroless-java-debian
@@ -1,0 +1,3 @@
+FROM gcr.io/distroless/java17-debian12:latest@sha256:8f80873debfafc0b77dd22d03e6d34d0a716c52404ca4ca19f76f2de11000c55
+
+CMD echo this is a dummy file used to automate dependency upgrades for plugins

--- a/.github/docker/Dockerfile.distroless-nodejs-debian
+++ b/.github/docker/Dockerfile.distroless-nodejs-debian
@@ -1,0 +1,3 @@
+FROM gcr.io/distroless/nodejs20-debian12:latest@sha256:6bd06494907b362c5d85dfbf60930e98272b9ffc1cbcb5c6d602da7ba9a303a0
+
+CMD echo this is a dummy file used to automate dependency upgrades for plugins

--- a/.github/docker/Dockerfile.distroless-static-debian
+++ b/.github/docker/Dockerfile.distroless-static-debian
@@ -1,0 +1,3 @@
+FROM gcr.io/distroless/static-debian12:latest@sha256:0c3d36f317d6335831765546ece49b60ad35933250dc14f43f0fd1402450532e
+
+CMD echo this is a dummy file used to automate dependency upgrades for plugins

--- a/.github/docker/Dockerfile.golang
+++ b/.github/docker/Dockerfile.golang
@@ -1,3 +1,3 @@
-FROM golang:1.21.4-bullseye
+FROM golang:1.21.4-bookworm
 
 CMD echo this is a dummy file used to automate dependency upgrades for plugins

--- a/.github/docker/Dockerfile.swift
+++ b/.github/docker/Dockerfile.swift
@@ -1,3 +1,3 @@
-FROM swift:5.9.1-focal
+FROM swift:5.9.1-jammy
 
 CMD echo this is a dummy file used to automate dependency upgrades for plugins


### PR DESCRIPTION
In order to improve reproducibility of builds, we should start to track distroless image updates. Add docker files for each flavor of distroless images we're using (additional follow up work is necessary to the fetch versions command to replace old versions with new ones).

Update debian/golang to bookworm going forward and update swift to use a 22.04 base image instead of the 20.04 one.