### PR TITLE
Prevent concurrent release jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ permissions:
   issues: write
   packages: read
 
+# Only allow a single release workflow to run at a time.
+concurrency: ${{ github.workflow }}
+
 jobs:
   release:
     environment: production


### PR DESCRIPTION
A release may fail if another release created the github release/tag in the meantime. This doesn't have any negative effects, however we should avoid failed workflows and only run a single release job at a time.

Fixes #935.