### PR TITLE
Group distroless updates together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,7 @@ updates:
     directory: "/.github/docker"
     schedule:
       interval: "daily"
+    groups:
+      distroless:
+        patterns:
+          - "distroless/*"


### PR DESCRIPTION
The distroless Docker images appear to be updated together. Group them into a single PR instead of 5.