### PR TITLE
Update test case for empty dir hash in gen dir

### DIFF
--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -37,7 +37,7 @@ type Plugin struct {
 }
 
 func (p *Plugin) String() string {
-	return fmt.Sprintf("%s:%s", p.Identity.IdentityString(), p.Version)
+	return fmt.Sprintf("%s:%s", p.Identity.IdentityString(), p.PluginVersion)
 }
 
 // Dependency represents a dependency one plugin has on another.

--- a/tests/plugins_test.go
+++ b/tests/plugins_test.go
@@ -83,6 +83,12 @@ func TestGeneration(t *testing.T) {
 			bufCmd.Dir = pluginDir
 			output, err := bufCmd.CombinedOutput()
 			require.NoErrorf(t, err, "buf generate failed - output: %s", string(output))
+			// Ensure the gen directory is not empty, otherwise we'll get a sum of an empty directory.
+			genDirFiles, err := os.ReadDir(pluginGenDir)
+			require.NoError(t, err, "failed to read generated code directory")
+			if len(genDirFiles) == 0 {
+				t.Fatal("generated code directory is empty")
+			}
 			genDirHash, err := dirhash.HashDir(pluginGenDir, "", dirhash.Hash1)
 			require.NoError(t, err, "failed to calculate directory hash of generated code")
 			pluginImageSumFile := filepath.Join(pluginDir, "plugin.sum")

--- a/tests/plugins_test.go
+++ b/tests/plugins_test.go
@@ -228,6 +228,7 @@ func createProtocGenPlugin(t *testing.T, basedir string, plugin *plugin.Plugin) 
 
 // isEmptyDirHash returns true if the given dirHash is the hash of an empty directory.
 func isEmptyDirHash(t *testing.T, dirHash string) bool {
+	t.Helper()
 	emptyDir := t.TempDir()
 	emptyDirHash, err := dirhash.HashDir(emptyDir, "", dirhash.Hash1)
 	require.NoError(t, err)


### PR DESCRIPTION
This PR adds a defensive check in our plugin tests to avoid passing plugins that generate no code and produce an "empty dir" hash.

There is a historical allowlist of plugins we'll allow, but moving forward we should craft protos to exercise valid code generation, in a similar way as:

https://github.com/bufbuild/plugins/blob/d524f5ffe0e922ac10752db571b60a320f7fc7f4/tests/plugins_test.go#L133-L13

For context, this would help catch https://github.com/bufbuild/plugins/pull/1017 against the typical images we pass in testing.

> --- FAIL: TestGeneration (0.42s)
    --- FAIL: TestGeneration/plugins/community/mercari-grpc-federation/v0.9.2 (0.00s)
        --- FAIL: TestGeneration/plugins/community/mercari-grpc-federation/v0.9.2/eliza (0.83s)
            plugins_test.go:99: generated code directory is empty for buf.build/community/mercari-grpc-federation:v0.9.2
        --- FAIL: TestGeneration/plugins/community/mercari-grpc-federation/v0.9.2/petapis (0.84s)
            plugins_test.go:99: generated code directory is empty for buf.build/community/mercari-grpc-federation:v0.9.2
FAIL
FAIL    github.com/bufbuild/plugins/tests       1.852s
FAIL
make: *** [test] Error 1