### PR TITLE
Add community/mfridman-go-json v1.2.0

### DIFF
--- a/plugins/community/mfridman-go-json/source.yaml
+++ b/plugins/community/mfridman-go-json/source.yaml
@@ -1,0 +1,4 @@
+source:
+  github:
+    owner: mfridman
+    repository: protoc-gen-go-json

--- a/plugins/community/mfridman-go-json/v1.2.0/.dockerignore
+++ b/plugins/community/mfridman-go-json/v1.2.0/.dockerignore
@@ -1,0 +1,2 @@
+*
+!Dockerfile

--- a/plugins/community/mfridman-go-json/v1.2.0/Dockerfile
+++ b/plugins/community/mfridman-go-json/v1.2.0/Dockerfile
@@ -1,0 +1,11 @@
+# syntax=docker/dockerfile:1.6
+FROM golang:1.21.6-bookworm AS build
+RUN --mount=type=cache,target=/go/pkg/mod \
+    CGO_ENABLED=0 \
+    go install -ldflags="-s -w" -trimpath github.com/mfridman/protoc-gen-go-json@v1.2.0
+
+FROM scratch
+COPY --from=build --link --chown=root:root /etc/passwd /etc/passwd
+COPY --from=build --link --chown=root:root /go/bin/protoc-gen-go-json .
+USER nobody
+ENTRYPOINT [ "/protoc-gen-go-json" ]

--- a/plugins/community/mfridman-go-json/v1.2.0/buf.plugin.yaml
+++ b/plugins/community/mfridman-go-json/v1.2.0/buf.plugin.yaml
@@ -1,0 +1,10 @@
+version: v1
+name: buf.build/community/mfridman-go-json
+plugin_version: v1.2.0
+source_url: https://github.com/mfridman/protoc-gen-go-json
+integration_guide_url: https://github.com/mfridman/protoc-gen-go-json#usage
+description: Generate marshalling & unmarshalling code using protojson.
+output_languages:
+  - go
+spdx_license_id: MIT
+license_url: https://github.com/mfridman/protoc-gen-go-json/blob/v1.2.0/LICENSE.md

--- a/plugins/community/mitchellh-go-json/source.yaml
+++ b/plugins/community/mitchellh-go-json/source.yaml
@@ -1,4 +1,7 @@
 source:
+  # Use mfridman/protoc-gen-go-json instead
+  # For more info, see https://gist.github.com/mitchellh/90029601268e59a29e64e55bab1c5bdc
+  disabled: true
   github:
     owner: mitchellh
     repository: protoc-gen-go-json

--- a/tests/testdata/buf.build/community/mfridman-go-json/v1.2.0/eliza/plugin.sum
+++ b/tests/testdata/buf.build/community/mfridman-go-json/v1.2.0/eliza/plugin.sum
@@ -1,0 +1,1 @@
+h1:JbopqKq2spPZ3zIQYc293w7pmDtYyjyQo38WP+zvzb4=

--- a/tests/testdata/buf.build/community/mfridman-go-json/v1.2.0/petapis/plugin.sum
+++ b/tests/testdata/buf.build/community/mfridman-go-json/v1.2.0/petapis/plugin.sum
@@ -1,0 +1,1 @@
+h1:Qi5ZKfam4ZBXkerC7L9HmKmypXYgdzj2FRQU0Zkg/Pk=


### PR DESCRIPTION
This PR adds a new community plugin which supersedes the existing one mitchellh/protoc-gen-go-json. I've disabled further updates of that plugin, and will mark it deprecated shortly.

This should also resolve the upstream issue folks have been asking about. https://github.com/mitchellh/protoc-gen-go-json/issues/17