### PR TITLE
Add connectrpc/swift plugin dependency for connectrpc/swift-mocks

### DIFF
--- a/plugins/connectrpc/swift-mocks/v0.12.0/buf.plugin.yaml
+++ b/plugins/connectrpc/swift-mocks/v0.12.0/buf.plugin.yaml
@@ -6,6 +6,7 @@ integration_guide_url: https://connectrpc.com/docs/swift/testing
 description: Generates mocks that are compatible with Connect-Swift clients.
 deps:
   - plugin: buf.build/apple/swift:v1.25.2
+  - plugin: buf.build/connectrpc/swift:v0.12.0
 output_languages:
   - swift
 registry:


### PR DESCRIPTION
This plugin depends on the output of the connect-swift generated code, so it needs a plugin dependency here to behave correctly with generated SDKs.

This is only currently fixing this issue in the latest connect-swift release; not sure if we want to backport it (I'm not clear on if this has always been an issue or was introduced in a particular update, but would lean towards the former?).

Ref: https://github.com/connectrpc/connect-swift/issues/250