### PR TITLE
Update grpc/go plugin to latest security release

### DIFF
--- a/plugins/grpc/go/v1.3.0/Dockerfile
+++ b/plugins/grpc/go/v1.3.0/Dockerfile
@@ -1,5 +1,9 @@
-# syntax=docker/dockerfile:1.4
-FROM golang:1.20.1-bullseye AS build
+# syntax=docker/dockerfile:1.7
+FROM --platform=$BUILDPLATFORM golang:1.22.2-bookworm AS build
+
+ARG TARGETOS TARGETARCH
+ENV CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH
+
 WORKDIR /tmp
 RUN git clone --depth 1 --branch cmd/protoc-gen-go-grpc/v1.3.0 https://github.com/grpc/grpc-go.git
 WORKDIR /tmp/grpc-go
@@ -69,11 +73,10 @@ index 340eaf3e..7f0fba56 100644
 EOF
 WORKDIR /tmp/grpc-go/cmd/protoc-gen-go-grpc
 RUN --mount=type=cache,target=/go/pkg/mod \
-    CGO_ENABLED=0 \
-    go build -ldflags "-s -w" -trimpath
+    go build -o protoc-gen-go-grpc -ldflags "-s -w" -trimpath
 
 FROM scratch
 COPY --from=build --link /etc/passwd /etc/passwd
-COPY --from=build --link --chown=root:root /tmp/grpc-go/cmd/protoc-gen-go-grpc .
+COPY --from=build --link --chown=root:root /tmp/grpc-go/cmd/protoc-gen-go-grpc/protoc-gen-go-grpc .
 USER nobody
 ENTRYPOINT [ "/protoc-gen-go-grpc" ]

--- a/plugins/grpc/go/v1.3.0/buf.plugin.yaml
+++ b/plugins/grpc/go/v1.3.0/buf.plugin.yaml
@@ -7,12 +7,12 @@ description: Generates Go client and server stubs for the gRPC framework.
 output_languages:
   - go
 deps:
-  - plugin: buf.build/protocolbuffers/go:v1.28.1
+  - plugin: buf.build/protocolbuffers/go:v1.34.0
 registry:
   go:
     deps:
       - module: google.golang.org/grpc
-        version: v1.53.0
+        version: v1.61.2
   opts:
     - paths=source_relative
     - require_unimplemented_servers=false


### PR DESCRIPTION
Update grpc/go to require the earliest version of the google.golang.org/grpc dependency with security fixes (v1.61.2). Update the plugin dependency to the latest version of protocolbuffers/go. Improve dockerfile to support multi-arch builds.

Fixes #1210.