### PR TITLE
Add dependency on prost for tonic

### DIFF
--- a/plugins/community/neoeinstein-tonic/v0.4.0/buf.plugin.yaml
+++ b/plugins/community/neoeinstein-tonic/v0.4.0/buf.plugin.yaml
@@ -3,6 +3,8 @@ name: buf.build/community/neoeinstein-tonic
 plugin_version: v0.4.0
 source_url: https://crates.io/crates/protoc-gen-tonic
 description: Generates Tonic gRPC server and client code using the Prost! code generation engine.
+deps:
+  - plugin: buf.build/community/neoeinstein-prost:v0.3.1
 output_languages:
   - rust
 spdx_license_id: Apache-2.0


### PR DESCRIPTION
Similar to grpc/go and connectrpc/go depending on protocolbuffers/go, tonic relies on prost codegen for the base message types.

Just adding this to the latest tonic version for now, but happy to go back and add it elsewhere (either here or as a follow-up).