### PR TITLE
Add pb/py->pb/pyi dependencies

### DIFF
--- a/plugins/protocolbuffers/pyi/v27.0/buf.plugin.yaml
+++ b/plugins/protocolbuffers/pyi/v27.0/buf.plugin.yaml
@@ -3,6 +3,8 @@ name: buf.build/protocolbuffers/pyi
 plugin_version: v27.0
 source_url: https://github.com/protocolbuffers/protobuf
 description: Base types for Python Stubs. Generates stub files for message and enum types.
+deps:
+  - plugin: buf.build/protocolbuffers/python:v27.0
 output_languages:
   - python
 spdx_license_id: BSD-3-Clause

--- a/plugins/protocolbuffers/pyi/v27.0/buf.plugin.yaml
+++ b/plugins/protocolbuffers/pyi/v27.0/buf.plugin.yaml
@@ -3,8 +3,6 @@ name: buf.build/protocolbuffers/pyi
 plugin_version: v27.0
 source_url: https://github.com/protocolbuffers/protobuf
 description: Base types for Python Stubs. Generates stub files for message and enum types.
-deps:
-  - plugin: buf.build/protocolbuffers/python:v27.0
 output_languages:
   - python
 spdx_license_id: BSD-3-Clause

--- a/plugins/protocolbuffers/python/v27.0/buf.plugin.yaml
+++ b/plugins/protocolbuffers/python/v27.0/buf.plugin.yaml
@@ -3,6 +3,8 @@ name: buf.build/protocolbuffers/python
 plugin_version: v27.0
 source_url: https://github.com/protocolbuffers/protobuf
 description: Base types for Python. Generates message and enum types.
+deps:
+  - plugin: buf.build/protocolbuffers/pyi:v27.0
 output_languages:
   - python
 spdx_license_id: BSD-3-Clause


### PR DESCRIPTION
Discussed this internally - we made the decision when releasing the Python Repository to not add a dependency between these plugins, specifically in the python->pyi direction, so that users that don't want type annotations don't need to have them included as a dependency.

However, if you _want_ type annotations, it's confusing to need to install both packages. Also, a `*_pyi` package is useless on its own (since it creates a [stub-only package][1]). Lastly, grpc/python comes with stubs built-in now, and protocolbuffers leans pretty heavily into types. Let's add this dependency relationship moving forward to simplify things for users.

For now, only adding this on the latest version - we can backport if there's significant interest.

[1]: https://peps.python.org/pep-0561/#stub-only-packages