### PR TITLE
Backport Python `protobuf` compatible versions to v25.*

### DIFF
--- a/plugins/protocolbuffers/python/v25.0/buf.plugin.yaml
+++ b/plugins/protocolbuffers/python/v25.0/buf.plugin.yaml
@@ -14,4 +14,4 @@ registry:
     requires_python: ">=3.8"
     deps:
       # https://pypi.org/project/protobuf/
-      - "protobuf"
+      - "protobuf~=4.25"

--- a/plugins/protocolbuffers/python/v25.1/buf.plugin.yaml
+++ b/plugins/protocolbuffers/python/v25.1/buf.plugin.yaml
@@ -14,4 +14,4 @@ registry:
     requires_python: ">=3.8"
     deps:
       # https://pypi.org/project/protobuf/
-      - "protobuf"
+      - "protobuf~=4.25"

--- a/plugins/protocolbuffers/python/v25.2/buf.plugin.yaml
+++ b/plugins/protocolbuffers/python/v25.2/buf.plugin.yaml
@@ -14,4 +14,4 @@ registry:
     requires_python: ">=3.8"
     deps:
       # https://pypi.org/project/protobuf/
-      - "protobuf"
+      - "protobuf~=4.25"

--- a/plugins/protocolbuffers/python/v25.3/buf.plugin.yaml
+++ b/plugins/protocolbuffers/python/v25.3/buf.plugin.yaml
@@ -14,4 +14,4 @@ registry:
     requires_python: ">=3.8"
     deps:
       # https://pypi.org/project/protobuf/
-      - "protobuf"
+      - "protobuf~=4.25"


### PR DESCRIPTION
We're already doing this for the v26 ([e.g.](https://github.com/bufbuild/plugins/blob/313fe18533139a4b3a70516a3082de038c6c4a67/plugins/protocolbuffers/python/v26.1/buf.plugin.yaml#L17)) and v27 plugins. v25 is the earliest release currently supported by Generated SDKs, and is on the [4.x releases](https://pypi.org/project/protobuf/#history) of `protobuf` — this just makes it easier for users to pin to these versions when other dependencies rely on a lower version of `protobuf`.

v25 also happens to be the earliest version of the plugins with Generated SDK support, so now we're covering all of our existing bases with these compatible version specifiers.