### PR TITLE
Backport Python `protobuf` compatible versions to pyi v25 versions

### DIFF
--- a/plugins/protocolbuffers/pyi/v25.0/buf.plugin.yaml
+++ b/plugins/protocolbuffers/pyi/v25.0/buf.plugin.yaml
@@ -14,5 +14,5 @@ registry:
     requires_python: ">=3.8"
     deps:
       # https://pypi.org/project/protobuf/
-      - "protobuf"
+      - "protobuf~=4.25"
       - "types-protobuf"

--- a/plugins/protocolbuffers/pyi/v25.1/buf.plugin.yaml
+++ b/plugins/protocolbuffers/pyi/v25.1/buf.plugin.yaml
@@ -14,5 +14,5 @@ registry:
     requires_python: ">=3.8"
     deps:
       # https://pypi.org/project/protobuf/
-      - "protobuf"
+      - "protobuf~=4.25"
       - "types-protobuf"

--- a/plugins/protocolbuffers/pyi/v25.2/buf.plugin.yaml
+++ b/plugins/protocolbuffers/pyi/v25.2/buf.plugin.yaml
@@ -14,5 +14,5 @@ registry:
     requires_python: ">=3.8"
     deps:
       # https://pypi.org/project/protobuf/
-      - "protobuf"
+      - "protobuf~=4.25"
       - "types-protobuf"

--- a/plugins/protocolbuffers/pyi/v25.3/buf.plugin.yaml
+++ b/plugins/protocolbuffers/pyi/v25.3/buf.plugin.yaml
@@ -14,5 +14,5 @@ registry:
     requires_python: ">=3.8"
     deps:
       # https://pypi.org/project/protobuf/
-      - "protobuf"
+      - "protobuf~=4.25"
       - "types-protobuf"


### PR DESCRIPTION
We backported these to protocolbuffers/python in #1266, but should also specify them here.