### PR TITLE
Validate plugin go min_version

### DIFF
--- a/tests/plugins_test.go
+++ b/tests/plugins_test.go
@@ -235,8 +235,8 @@ func TestGoMinVersion(t *testing.T) {
 			}
 			assert.Equalf(
 				t,
-				minVersion,
 				strings.TrimPrefix(maxMajorMinor, "v"),
+				minVersion,
 				"expected go plugin registry.go.min_version %q to be equal to the max version of its dependencies %q (%s)",
 				minVersion,
 				strings.TrimPrefix(maxMajorMinor, "v"),

--- a/tests/plugins_test.go
+++ b/tests/plugins_test.go
@@ -237,7 +237,7 @@ func TestGoMinVersion(t *testing.T) {
 				t,
 				minVersion,
 				strings.TrimPrefix(maxMajorMinor, "v"),
-				"expected go plugin registry.go.min_version to be equal to the max version of its dependencies %q (%s)",
+				"expected go plugin registry.go.min_version %q to be equal to the max version of its dependencies %q (%s)",
 				minVersion,
 				strings.TrimPrefix(maxMajorMinor, "v"),
 				maxDep,


### PR DESCRIPTION
Plugins supporting generated SDKs for Go need to ensure they set a min_version to be equal to the greatest version of any of their declared dependencies.