### PR TITLE
Require protobuf dep to be at least gencode level

### DIFF
--- a/plugins/protocolbuffers/pyi/v27.2/buf.plugin.yaml
+++ b/plugins/protocolbuffers/pyi/v27.2/buf.plugin.yaml
@@ -14,5 +14,5 @@ registry:
     requires_python: ">=3.8"
     deps:
       # https://pypi.org/project/protobuf/
-      - "protobuf~=5.27"
+      - "protobuf~=5.27.2"
       - "types-protobuf~=5.27"

--- a/plugins/protocolbuffers/python/v27.2/buf.plugin.yaml
+++ b/plugins/protocolbuffers/python/v27.2/buf.plugin.yaml
@@ -16,4 +16,4 @@ registry:
     requires_python: ">=3.8"
     deps:
       # https://pypi.org/project/protobuf/
-      - "protobuf~=5.27"
+      - "protobuf~=5.27.2"


### PR DESCRIPTION
Update the python plugins to ensure we require a dependency version of the protobuf library to be at least the same version of the gencode. Without this constraint, users that have an earlier 5.27.0 or 5.27.1 version of the protobuf dependency already installed will fail at runtime.

See https://protobuf.dev/support/cross-version-runtime-guarantee/ for more details.