### PR TITLE
Fix python v26.1 plugin dependencies

### DIFF
--- a/plugins/protocolbuffers/pyi/v26.1/Dockerfile
+++ b/plugins/protocolbuffers/pyi/v26.1/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
  && apt-get install -y curl git cmake build-essential g++ unzip zip
 RUN arch=${TARGETARCH}; \
     if [ "${arch}" = "amd64" ]; then arch="x86_64"; fi; \
-    curl -fsSL -o /usr/local/bin/bazel https://github.com/bazelbuild/bazel/releases/download/7.2.1/bazel-7.2.1-linux-${arch} \
+    curl -fsSL -o /usr/local/bin/bazel https://github.com/bazelbuild/bazel/releases/download/7.1.1/bazel-7.1.1-linux-${arch} \
  && chmod +x /usr/local/bin/bazel
 
 WORKDIR /build

--- a/plugins/protocolbuffers/pyi/v26.1/Dockerfile
+++ b/plugins/protocolbuffers/pyi/v26.1/Dockerfile
@@ -1,5 +1,5 @@
-# syntax=docker/dockerfile:1.7
-FROM debian:bookworm-20240311 AS build
+# syntax=docker/dockerfile:1.8
+FROM debian:bookworm-20240612 AS build
 
 ARG TARGETARCH
 
@@ -7,7 +7,7 @@ RUN apt-get update \
  && apt-get install -y curl git cmake build-essential g++ unzip zip
 RUN arch=${TARGETARCH}; \
     if [ "${arch}" = "amd64" ]; then arch="x86_64"; fi; \
-    curl -fsSL -o /usr/local/bin/bazel https://github.com/bazelbuild/bazel/releases/download/7.1.1/bazel-7.1.1-linux-${arch} \
+    curl -fsSL -o /usr/local/bin/bazel https://github.com/bazelbuild/bazel/releases/download/7.2.1/bazel-7.2.1-linux-${arch} \
  && chmod +x /usr/local/bin/bazel
 
 WORKDIR /build
@@ -18,7 +18,10 @@ RUN bazel build '//:protoc_lib'
 COPY BUILD pyi.cc plugins/
 RUN bazel build '//plugins:protoc-gen-pyi.stripped'
 
-FROM gcr.io/distroless/cc-debian12:latest@sha256:e6ae66a5a343d7112167f9117c4e630cfffcd80db44e44302759ec13ddd2d22b
+FROM gcr.io/distroless/cc-debian12:latest@sha256:e1065a1d58800a7294f74e67c32ec4146d09d6cbe471c1fa7ed456b2d2bf06e0 AS base
+
+FROM scratch
+COPY --from=base / /
 COPY --from=build --link --chmod=0755 /build/bazel-bin/plugins/protoc-gen-pyi .
 USER nobody
 ENTRYPOINT ["/protoc-gen-pyi"]

--- a/plugins/protocolbuffers/pyi/v26.1/buf.plugin.yaml
+++ b/plugins/protocolbuffers/pyi/v26.1/buf.plugin.yaml
@@ -14,5 +14,5 @@ registry:
     requires_python: ">=3.8"
     deps:
       # https://pypi.org/project/protobuf/
-      - "protobuf~=5.26"
-      - "types-protobuf"
+      - "protobuf~=5.26.1"
+      - "types-protobuf~=5.26"

--- a/plugins/protocolbuffers/python/v26.1/Dockerfile
+++ b/plugins/protocolbuffers/python/v26.1/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
  && apt-get install -y curl git cmake build-essential g++ unzip zip
 RUN arch=${TARGETARCH}; \
     if [ "${arch}" = "amd64" ]; then arch="x86_64"; fi; \
-    curl -fsSL -o /usr/local/bin/bazel https://github.com/bazelbuild/bazel/releases/download/7.2.1/bazel-7.2.1-linux-${arch} \
+    curl -fsSL -o /usr/local/bin/bazel https://github.com/bazelbuild/bazel/releases/download/7.1.1/bazel-7.1.1-linux-${arch} \
  && chmod +x /usr/local/bin/bazel
 
 WORKDIR /build

--- a/plugins/protocolbuffers/python/v26.1/Dockerfile
+++ b/plugins/protocolbuffers/python/v26.1/Dockerfile
@@ -1,5 +1,5 @@
-# syntax=docker/dockerfile:1.7
-FROM debian:bookworm-20240311 AS build
+# syntax=docker/dockerfile:1.8
+FROM debian:bookworm-20240612 AS build
 
 ARG TARGETARCH
 
@@ -7,7 +7,7 @@ RUN apt-get update \
  && apt-get install -y curl git cmake build-essential g++ unzip zip
 RUN arch=${TARGETARCH}; \
     if [ "${arch}" = "amd64" ]; then arch="x86_64"; fi; \
-    curl -fsSL -o /usr/local/bin/bazel https://github.com/bazelbuild/bazel/releases/download/7.1.1/bazel-7.1.1-linux-${arch} \
+    curl -fsSL -o /usr/local/bin/bazel https://github.com/bazelbuild/bazel/releases/download/7.2.1/bazel-7.2.1-linux-${arch} \
  && chmod +x /usr/local/bin/bazel
 
 WORKDIR /build
@@ -18,7 +18,10 @@ RUN bazel build '//:protoc_lib'
 COPY --link BUILD python.cc plugins/
 RUN bazel build '//plugins:protoc-gen-python.stripped'
 
-FROM gcr.io/distroless/cc-debian12:latest@sha256:e6ae66a5a343d7112167f9117c4e630cfffcd80db44e44302759ec13ddd2d22b
+FROM gcr.io/distroless/cc-debian12:latest@sha256:e1065a1d58800a7294f74e67c32ec4146d09d6cbe471c1fa7ed456b2d2bf06e0 AS base
+
+FROM scratch
+COPY --from=base --link / /
 COPY --from=build --link --chmod=0755 /build/bazel-bin/plugins/protoc-gen-python .
 USER nobody
 ENTRYPOINT ["/protoc-gen-python"]

--- a/plugins/protocolbuffers/python/v26.1/buf.plugin.yaml
+++ b/plugins/protocolbuffers/python/v26.1/buf.plugin.yaml
@@ -3,6 +3,8 @@ name: buf.build/protocolbuffers/python
 plugin_version: v26.1
 source_url: https://github.com/protocolbuffers/protobuf
 description: Base types for Python. Generates message and enum types.
+deps:
+  - plugin: buf.build/protocolbuffers/pyi:v26.1
 output_languages:
   - python
 spdx_license_id: BSD-3-Clause
@@ -14,4 +16,4 @@ registry:
     requires_python: ">=3.8"
     deps:
       # https://pypi.org/project/protobuf/
-      - "protobuf~=5.26"
+      - "protobuf~=5.26.1"


### PR DESCRIPTION
Update python v26.1 plugin dependencies to pull in the same or later version of the protobuf library. While we're rebuilding plugins, reduce additional layers in the Python v26.1 plugins and add a dependency on pyi plugin to match updates in later versions.

Ref: https://github.com/bufbuild/plugins/pull/1319