### PR TITLE
Specify version of types-protobuf

### DIFF
--- a/plugins/protocolbuffers/pyi/v27.1/buf.plugin.yaml
+++ b/plugins/protocolbuffers/pyi/v27.1/buf.plugin.yaml
@@ -15,4 +15,5 @@ registry:
     deps:
       # https://pypi.org/project/protobuf/
       - "protobuf~=5.27.1"
-      - "types-protobuf"
+      # https://pypi.org/project/types-protobuf/
+      - "types-protobuf~=5.27"


### PR DESCRIPTION
Now that there is a 5.x version available, update the buf.plugin.yaml to target a specific version.