### PR TITLE
Update grpc-go plugin dependency to 1.62.0

### DIFF
--- a/plugins/grpc/go/v1.4.0/buf.plugin.yaml
+++ b/plugins/grpc/go/v1.4.0/buf.plugin.yaml
@@ -10,6 +10,7 @@ deps:
   - plugin: buf.build/protocolbuffers/go:v1.34.2
 registry:
   go:
+    min_version: "1.19"
     deps:
       - module: google.golang.org/grpc
         version: v1.62.2

--- a/plugins/grpc/go/v1.4.0/buf.plugin.yaml
+++ b/plugins/grpc/go/v1.4.0/buf.plugin.yaml
@@ -7,12 +7,12 @@ description: Generates Go client and server stubs for the gRPC framework.
 output_languages:
   - go
 deps:
-  - plugin: buf.build/protocolbuffers/go:v1.34.1
+  - plugin: buf.build/protocolbuffers/go:v1.34.2
 registry:
   go:
     deps:
       - module: google.golang.org/grpc
-        version: v1.61.2
+        version: v1.62.2
   opts:
     - paths=source_relative
     - require_unimplemented_servers=false


### PR DESCRIPTION
The protoc-gen-grpc-go plugin updated in v1.4.0 to require at least grpc-go v1.62.0 of generated code. Update to v1.62.2 to require the latest security release of grpc-go.

Additionally, bump the version of the protocolbuffers/go dependency.