### PR TITLE
Automatically replace docker syntax to the desired version when fetching

### DIFF
--- a/internal/cmd/fetcher/main.go
+++ b/internal/cmd/fetcher/main.go
@@ -25,9 +25,11 @@ import (
 )
 
 var (
-	bazelDownloadRegexp = regexp.MustCompile(`bazelbuild/bazel/releases/download/[^/]+/bazel-[^-]+-linux`)
-	bazelImageName      = "gcr.io/bazel-public/bazel"
-	errNoVersions       = errors.New("no versions found")
+	bazelDownloadRegexp   = regexp.MustCompile(`bazelbuild/bazel/releases/download/[^/]+/bazel-[^-]+-linux`)
+	bazelImageName        = "gcr.io/bazel-public/bazel"
+	errNoVersions         = errors.New("no versions found")
+	dockerSyntaxPrefix    = "# syntax=docker/dockerfile:"
+	preferredDockerSyntax = "1.9"
 )
 
 func main() {
@@ -334,6 +336,8 @@ func copyFile(
 					line = strings.Join(fields, " ")
 				}
 			}
+		} else if isDockerfile && strings.HasPrefix(line, dockerSyntaxPrefix) {
+			line = dockerSyntaxPrefix + preferredDockerSyntax
 		}
 		if _, err := fmt.Fprintln(destFile, line); err != nil {
 			return err

--- a/internal/cmd/fetcher/main.go
+++ b/internal/cmd/fetcher/main.go
@@ -336,7 +336,8 @@ func copyFile(
 					line = strings.Join(fields, " ")
 				}
 			}
-		} else if isDockerfile && strings.HasPrefix(line, dockerSyntaxPrefix) {
+		}
+		if isDockerfile && strings.HasPrefix(line, dockerSyntaxPrefix) {
 			line = dockerSyntaxPrefix + preferredDockerSyntax
 		}
 		if _, err := fmt.Fprintln(destFile, line); err != nil {

--- a/internal/cmd/fetcher/main.go
+++ b/internal/cmd/fetcher/main.go
@@ -25,11 +25,11 @@ import (
 )
 
 var (
-	bazelDownloadRegexp   = regexp.MustCompile(`bazelbuild/bazel/releases/download/[^/]+/bazel-[^-]+-linux`)
-	bazelImageName        = "gcr.io/bazel-public/bazel"
-	errNoVersions         = errors.New("no versions found")
-	dockerSyntaxPrefix    = "# syntax=docker/dockerfile:"
-	preferredDockerSyntax = "1.9"
+	bazelDownloadRegexp    = regexp.MustCompile(`bazelbuild/bazel/releases/download/[^/]+/bazel-[^-]+-linux`)
+	bazelImageName         = "gcr.io/bazel-public/bazel"
+	dockerfileImageName    = "docker/dockerfile"
+	dockerfileSyntaxPrefix = "# syntax=docker/dockerfile:"
+	errNoVersions          = errors.New("no versions found")
 )
 
 func main() {
@@ -308,6 +308,10 @@ func copyFile(
 	if latestBazelVersion == "" {
 		return fmt.Errorf("failed to find latest version for bazel image %q", bazelImageName)
 	}
+	latestDockerfileVersion := latestBaseImages.ImageVersion(dockerfileImageName)
+	if latestDockerfileVersion == "" {
+		return fmt.Errorf("failed to find latest version for dockerfile image %q", bazelImageName)
+	}
 	s := bufio.NewScanner(srcFile)
 	for s.Scan() {
 		line := strings.ReplaceAll(s.Text(), prevVersion, newVersion)
@@ -337,8 +341,8 @@ func copyFile(
 				}
 			}
 		}
-		if isDockerfile && strings.HasPrefix(line, dockerSyntaxPrefix) {
-			line = dockerSyntaxPrefix + preferredDockerSyntax
+		if isDockerfile && strings.HasPrefix(line, dockerfileSyntaxPrefix) {
+			line = dockerfileSyntaxPrefix + latestDockerfileVersion
 		}
 		if _, err := fmt.Fprintln(destFile, line); err != nil {
 			return err


### PR DESCRIPTION
This would automatically replace `# syntax=docker/dockerfile:1.7` at the top of the Dockerfile to 1.9.