### PR TITLE
Add import_extension option to bufbuild/es v2

### DIFF
--- a/plugins/bufbuild/es/v2.0.0/buf.plugin.yaml
+++ b/plugins/bufbuild/es/v2.0.0/buf.plugin.yaml
@@ -8,6 +8,8 @@ output_languages:
   - javascript
   - typescript
 registry:
+  opts:
+    - import_extension=js
   npm:
     import_style: module
     rewrite_import_path_suffix: pb.js

--- a/tests/testdata/buf.build/bufbuild/es/v2.0.0/eliza/plugin.sum
+++ b/tests/testdata/buf.build/bufbuild/es/v2.0.0/eliza/plugin.sum
@@ -1,1 +1,1 @@
-h1:LyFw1BwnYvlTQGyafosQmieVEcD0k466x48SbFrfvWI=
+h1:pa9XdjYIz2RryCBaPz0/O+oJbumU37cRFFYtXCxkfRE=

--- a/tests/testdata/buf.build/bufbuild/es/v2.0.0/petapis/plugin.sum
+++ b/tests/testdata/buf.build/bufbuild/es/v2.0.0/petapis/plugin.sum
@@ -1,1 +1,1 @@
-h1:GjGY5hxrz4gFytMjCKI2xXvr340uKVinp71EieVpuDw=
+h1:QW+OkSjxu7M5PNCu8pfifoLDgdFOV0Nnr9UxiM4Grxo=


### PR DESCRIPTION
This PR adds the plugin option `import_extension=js` to the `bufbuild/es` plugin.

@timostamm, correct me if I'm wrong, but in v1 the default was `.js`, which means we always generated imports with extensions. But in v2, the default is none.

However, I believe this breaks BSR-generated SDKs that have dependencies and setting the above should fix it.

A reproducible example is:

```
npm init -y
# set project to "type": "module"

npm config set @buf:registry https://buf.build/gen/npm/v1/
npm install @buf/acme_petapis.bufbuild_es@latest
```

I'd expect this to work:

```js
import { GetPetRequestSchema } from "@buf/acme_petapis.bufbuild_es/pet/v1/pet_pb.js";
import { create, toJson } from "@bufbuild/protobuf";
let request = create(GetPetRequestSchema, {
  petId: "123",
});
const json = toJson(GetPetRequestSchema, request);
console.log(json);

```

But instead I get an error:

```
node:internal/modules/run_main:115
    triggerUncaughtException(
    ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/mfridman/debug-npm/node_modules/@buf/googleapis_googleapis.bufbuild_es/google/type/datetime_pb' imported from /Users/mfridman/debug-npm/node_modules/@buf/acme_petapis.bufbuild_es/pet/v1/pet_pb.js
Did you mean to import "@buf/googleapis_googleapis.bufbuild_es/google/type/datetime_pb.js"?
    at finalizeResolution (node:internal/modules/esm/resolve:260:11)
    at moduleResolve (node:internal/modules/esm/resolve:920:10)
    at defaultResolve (node:internal/modules/esm/resolve:1119:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:541:12)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:510:25)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:240:38)
    at ModuleJob._link (node:internal/modules/esm/module_job:126:49) {
  code: 'ERR_MODULE_NOT_FOUND',
  url: 'file:///Users/mfridman/debug-npm/node_modules/@buf/googleapis_googleapis.bufbuild_es/google/type/datetime_pb'
}

Node.js v22.3.0
```

The crux of the problem is the imports in the generated code are missing extensions, so the question is it me misconfiguring my environment/project, or should we always generate SDKs that include the extension?

```js
import { enumDesc, fileDesc, messageDesc, serviceDesc, tsEnum } from "@bufbuild/protobuf/codegenv1";
import { file_google_type_datetime } from "@buf/googleapis_googleapis.bufbuild_es/google/type/datetime_pb";
import { file_payment_v1alpha1_payment } from "@buf/acme_paymentapis.bufbuild_es/payment/v1alpha1/payment_pb";
```