### PR TITLE
Set `bytes=.` option for community/neoeinstein-prost generated SDKs

### DIFF
--- a/plugins/community/neoeinstein-prost/v0.3.1/buf.plugin.yaml
+++ b/plugins/community/neoeinstein-prost/v0.3.1/buf.plugin.yaml
@@ -26,3 +26,7 @@ registry:
   opts:
     # Includes the encoded FileDescriptorSet in the generated output for each module.
     - file_descriptor_set
+    # Change generation of bytes type fields into Rust `bytes::Bytes` types.
+    # Dependency on `bytes` crate is added as a result of `default_features: true` on `prost` dependency.
+    # https://crates.io/crates/prost/0.12.6/dependencies
+    - bytes=.


### PR DESCRIPTION
This option will change the generated code for the protobuf `bytes` type fields from `Vec<u8>` types to `bytes::Bytes` types from the `bytes` crate. We believe that this type is more ergonomic in most cases for most users, and that the additional dependency is warranted for Generated SDKs.