### PR TITLE
Add `Grpc.Net.Client` dependency to grpc/csharp

### DIFF
--- a/plugins/grpc/csharp/v1.65.0/buf.plugin.yaml
+++ b/plugins/grpc/csharp/v1.65.0/buf.plugin.yaml
@@ -18,3 +18,5 @@ registry:
     deps:
       - name: Grpc.Net.Common
         version: 2.63.0
+      - name: Grpc.Net.Client
+        version: 2.63.0

--- a/plugins/grpc/csharp/v1.65.0/build.csproj
+++ b/plugins/grpc/csharp/v1.65.0/build.csproj
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Grpc.Net.Common" Version="2.63.0" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.63.0" />
     <PackageReference Include="Google.Protobuf" Version="3.26.1" />
   </ItemGroup>
 </Project>

--- a/plugins/grpc/csharp/v1.65.1/buf.plugin.yaml
+++ b/plugins/grpc/csharp/v1.65.1/buf.plugin.yaml
@@ -18,3 +18,5 @@ registry:
     deps:
       - name: Grpc.Net.Common
         version: 2.63.0
+      - name: Grpc.Net.Client
+        version: 2.63.0

--- a/plugins/grpc/csharp/v1.65.1/build.csproj
+++ b/plugins/grpc/csharp/v1.65.1/build.csproj
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Grpc.Net.Common" Version="2.63.0" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.63.0" />
     <PackageReference Include="Google.Protobuf" Version="3.26.1" />
   </ItemGroup>
 </Project>

--- a/plugins/grpc/csharp/v1.65.2/buf.plugin.yaml
+++ b/plugins/grpc/csharp/v1.65.2/buf.plugin.yaml
@@ -18,3 +18,5 @@ registry:
     deps:
       - name: Grpc.Net.Common
         version: 2.63.0
+      - name: Grpc.Net.Client
+        version: 2.63.0

--- a/plugins/grpc/csharp/v1.65.2/build.csproj
+++ b/plugins/grpc/csharp/v1.65.2/build.csproj
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Grpc.Net.Common" Version="2.63.0" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.63.0" />
     <PackageReference Include="Google.Protobuf" Version="3.26.1" />
   </ItemGroup>
 </Project>

--- a/plugins/grpc/csharp/v1.65.4/buf.plugin.yaml
+++ b/plugins/grpc/csharp/v1.65.4/buf.plugin.yaml
@@ -18,3 +18,5 @@ registry:
     deps:
       - name: Grpc.Net.Common
         version: 2.63.0
+      - name: Grpc.Net.Client
+        version: 2.63.0

--- a/plugins/grpc/csharp/v1.65.4/build.csproj
+++ b/plugins/grpc/csharp/v1.65.4/build.csproj
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Grpc.Net.Common" Version="2.63.0" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.63.0" />
     <PackageReference Include="Google.Protobuf" Version="3.26.1" />
   </ItemGroup>
 </Project>

--- a/plugins/grpc/csharp/v1.65.5/buf.plugin.yaml
+++ b/plugins/grpc/csharp/v1.65.5/buf.plugin.yaml
@@ -18,3 +18,5 @@ registry:
     deps:
       - name: Grpc.Net.Common
         version: 2.63.0
+      - name: Grpc.Net.Client
+        version: 2.63.0

--- a/plugins/grpc/csharp/v1.65.5/build.csproj
+++ b/plugins/grpc/csharp/v1.65.5/build.csproj
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Grpc.Net.Common" Version="2.63.0" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.63.0" />
     <PackageReference Include="Google.Protobuf" Version="3.26.1" />
   </ItemGroup>
 </Project>

--- a/plugins/grpc/csharp/v1.66.0/buf.plugin.yaml
+++ b/plugins/grpc/csharp/v1.66.0/buf.plugin.yaml
@@ -18,3 +18,5 @@ registry:
     deps:
       - name: Grpc.Net.Common
         version: 2.65.0
+      - name: Grpc.Net.Client
+        version: 2.65.0

--- a/plugins/grpc/csharp/v1.66.0/build.csproj
+++ b/plugins/grpc/csharp/v1.66.0/build.csproj
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Grpc.Net.Common" Version="2.65.0" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.65.0" />
     <PackageReference Include="Google.Protobuf" Version="3.27.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Matching with the `Grpc.Net.Common` dependency version.