### PR TITLE
Check for Maven lite dependencies

### DIFF
--- a/tests/plugins_test.go
+++ b/tests/plugins_test.go
@@ -280,13 +280,9 @@ func TestMavenDependencies(t *testing.T) {
 		t.Run(fmt.Sprintf("%s/%s@%s", p.Identity.Owner(), p.Identity.Plugin(), p.PluginVersion), func(t *testing.T) {
 			t.Parallel()
 			var alldeps []string
-			for _, dep := range p.Registry.Maven.Deps {
-				alldeps = append(alldeps, dep)
-			}
+			alldeps = append(alldeps, p.Registry.Maven.Deps...)
 			for _, runtime := range p.Registry.Maven.AdditionalRuntimes {
-				for _, dep := range runtime.Deps {
-					alldeps = append(alldeps, dep)
-				}
+				alldeps = append(alldeps, runtime.Deps...)
 			}
 			for _, dep := range alldeps {
 				fields := strings.Split(dep, ":")

--- a/tests/plugins_test.go
+++ b/tests/plugins_test.go
@@ -279,7 +279,16 @@ func TestMavenDependencies(t *testing.T) {
 		}
 		t.Run(fmt.Sprintf("%s/%s@%s", p.Identity.Owner(), p.Identity.Plugin(), p.PluginVersion), func(t *testing.T) {
 			t.Parallel()
+			var alldeps []string
 			for _, dep := range p.Registry.Maven.Deps {
+				alldeps = append(alldeps, dep)
+			}
+			for _, runtime := range p.Registry.Maven.AdditionalRuntimes {
+				for _, dep := range runtime.Deps {
+					alldeps = append(alldeps, dep)
+				}
+			}
+			for _, dep := range alldeps {
 				fields := strings.Split(dep, ":")
 				require.Len(t, fields, 3)
 				groupID, artifactID, version := fields[0], fields[1], fields[2]


### PR DESCRIPTION
In addition to checking that dependencies exist for the full (default) runtime, we should also ensure any dependencies of the lite runtime exist as well.