### PR TITLE
Remove output_language because it should be 'other' and not 'go'

### DIFF
--- a/plugins/community/google-gnostic-openapi/v0.7.0/buf.plugin.yaml
+++ b/plugins/community/google-gnostic-openapi/v0.7.0/buf.plugin.yaml
@@ -4,7 +4,5 @@ plugin_version: v0.7.0
 source_url: https://github.com/google/gnostic
 integration_guide_url: https://github.com/google/gnostic#installation-and-getting-started
 description: Generates an OpenAPI description for a REST API that corresponds to a Protocol Buffer service.
-output_languages:
-  - go
 spdx_license_id: Apache-2.0
 license_url: https://github.com/google/gnostic/blob/v0.7.0/LICENSE


### PR DESCRIPTION
Fixes https://github.com/bufbuild/plugins/issues/1519