### PR TITLE
Add apple/swift v1.28.2 plugin

### DIFF
--- a/plugins/apple/swift/v1.28.2/.dockerignore
+++ b/plugins/apple/swift/v1.28.2/.dockerignore
@@ -1,0 +1,3 @@
+*
+!Dockerfile
+!extramoduleimports.patch

--- a/plugins/apple/swift/v1.28.2/Dockerfile
+++ b/plugins/apple/swift/v1.28.2/Dockerfile
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1.10
+FROM swift:5.10.1-bookworm AS build
+
+RUN apt-get update \
+ && apt-get install -y libstdc++-12-dev
+COPY --link extramoduleimports.patch /app/extramoduleimports.patch
+WORKDIR /app
+RUN git clone --depth 1 --branch 1.28.2 https://github.com/apple/swift-protobuf --recursive
+WORKDIR /app/swift-protobuf
+RUN git apply /app/extramoduleimports.patch
+RUN swift build -c release --static-swift-stdlib -Xlinker -s
+
+FROM gcr.io/distroless/cc-debian12:latest@sha256:3310655aac0d85eb9d579792387af1ff3eb7a1667823478be58020ab0e0d97a8 AS base
+
+FROM scratch
+COPY --link --from=base / /
+COPY --link --from=build /app/swift-protobuf/.build/release/protoc-gen-swift .
+USER nobody
+ENTRYPOINT [ "/protoc-gen-swift" ]

--- a/plugins/apple/swift/v1.28.2/buf.plugin.yaml
+++ b/plugins/apple/swift/v1.28.2/buf.plugin.yaml
@@ -1,0 +1,21 @@
+version: v1
+name: buf.build/apple/swift
+plugin_version: v1.28.2
+source_url: https://github.com/apple/swift-protobuf
+integration_guide_url: https://github.com/apple/swift-protobuf#getting-started
+description: Base types for Swift. Generates message and enum types.
+output_languages:
+  - swift
+registry:
+  swift:
+    deps:
+      - source: https://github.com/apple/swift-protobuf.git
+        package: swift-protobuf
+        swift_versions: [ ".v5" ]
+        products: [ SwiftProtobuf ]
+        version: 1.28.2
+  opts:
+    - Visibility=Public
+    - FileNaming=PathToUnderscores
+spdx_license_id: Apache-2.0
+license_url: https://github.com/apple/swift-protobuf/blob/1.28.2/LICENSE.txt

--- a/plugins/apple/swift/v1.28.2/extramoduleimports.patch
+++ b/plugins/apple/swift/v1.28.2/extramoduleimports.patch
@@ -1,8 +1,8 @@
 diff --git a/Sources/protoc-gen-swift/FileGenerator.swift b/Sources/protoc-gen-swift/FileGenerator.swift
-index 6238fd10..e5d957da 100644
+index f0cddb24..e5864211 100644
 --- a/Sources/protoc-gen-swift/FileGenerator.swift
 +++ b/Sources/protoc-gen-swift/FileGenerator.swift
-@@ -133,6 +133,14 @@ class FileGenerator {
+@@ -149,6 +149,14 @@ class FileGenerator {
              return
          }
  
@@ -18,43 +18,46 @@ index 6238fd10..e5d957da 100644
          generateVersionCheck(printer: &p)
  
 diff --git a/Sources/protoc-gen-swift/GeneratorOptions.swift b/Sources/protoc-gen-swift/GeneratorOptions.swift
-index bf9d9cdb..653ea0f1 100644
+index 3224e138..8bfc1ce5 100644
 --- a/Sources/protoc-gen-swift/GeneratorOptions.swift
 +++ b/Sources/protoc-gen-swift/GeneratorOptions.swift
 @@ -64,6 +64,7 @@ class GeneratorOptions {
-     }
-   }
- 
-+  let extraModuleImports: [String]
-   let outputNaming: OutputNaming
-   let protoToModuleMappings: ProtoFileToModuleMappings
-   let visibility: Visibility
-@@ -74,6 +75,7 @@ class GeneratorOptions {
-   let visibilitySourceSnippet: String
- 
-   init(parameter: any CodeGeneratorParameter) throws {
-+    var externalModuleImports: [String] = []
-     var outputNaming: OutputNaming = .fullPath
-     var moduleMapPath: String?
-     var visibility: Visibility = .internal
-@@ -138,6 +140,12 @@ class GeneratorOptions {
-           throw GenerationError.invalidParameterValue(name: pair.key,
-                                                       value: pair.value)
          }
-+      case "ExtraModuleImports":
-+        if !pair.value.isEmpty {
-+            externalModuleImports.append(pair.value)
-+        } else {
-+          throw GenerationError.invalidParameterValue(name: pair.key, value: pair.value)
-+        }
-       default:
-         throw GenerationError.unknownParameter(name: pair.key)
-       }
-@@ -167,6 +175,7 @@ class GeneratorOptions {
-       visibilitySourceSnippet = "package "
      }
  
-+    self.extraModuleImports = externalModuleImports
-     self.experimentalStripNonfunctionalCodegen = experimentalStripNonfunctionalCodegen
++    let extraModuleImports: [String]
+     let outputNaming: OutputNaming
+     let protoToModuleMappings: ProtoFileToModuleMappings
+     let visibility: Visibility
+@@ -74,6 +75,7 @@ class GeneratorOptions {
+     let visibilitySourceSnippet: String
  
-     switch (implementationOnlyImports, useAccessLevelOnImports) {
+     init(parameter: any CodeGeneratorParameter) throws {
++        var externalModuleImports: [String] = []
+         var outputNaming: OutputNaming = .fullPath
+         var moduleMapPath: String?
+         var visibility: Visibility = .internal
+@@ -146,6 +148,15 @@ class GeneratorOptions {
+                         value: pair.value
+                     )
+                 }
++            case "ExtraModuleImports":
++                if !pair.value.isEmpty {
++                    externalModuleImports.append(pair.value)
++                } else {
++                    throw GenerationError.invalidParameterValue(
++                        name: pair.key,
++                        value: pair.value
++                    )
++                }
+             default:
+                 throw GenerationError.unknownParameter(name: pair.key)
+             }
+@@ -179,6 +190,7 @@ class GeneratorOptions {
+             visibilitySourceSnippet = "package "
+         }
+ 
++        self.extraModuleImports = externalModuleImports
+         self.experimentalStripNonfunctionalCodegen = experimentalStripNonfunctionalCodegen
+ 
+         switch (implementationOnlyImports, useAccessLevelOnImports) {

--- a/plugins/apple/swift/v1.28.2/extramoduleimports.patch
+++ b/plugins/apple/swift/v1.28.2/extramoduleimports.patch
@@ -1,0 +1,60 @@
+diff --git a/Sources/protoc-gen-swift/FileGenerator.swift b/Sources/protoc-gen-swift/FileGenerator.swift
+index 6238fd10..e5d957da 100644
+--- a/Sources/protoc-gen-swift/FileGenerator.swift
++++ b/Sources/protoc-gen-swift/FileGenerator.swift
+@@ -133,6 +133,14 @@ class FileGenerator {
+             return
+         }
+ 
++        let neededCustomImports = generatorOptions.extraModuleImports
++        if !neededCustomImports.isEmpty {
++            p.print()
++            for i in neededCustomImports {
++                p.print("import \(i)\n")
++            }
++        }
++
+         p.print()
+         generateVersionCheck(printer: &p)
+ 
+diff --git a/Sources/protoc-gen-swift/GeneratorOptions.swift b/Sources/protoc-gen-swift/GeneratorOptions.swift
+index bf9d9cdb..653ea0f1 100644
+--- a/Sources/protoc-gen-swift/GeneratorOptions.swift
++++ b/Sources/protoc-gen-swift/GeneratorOptions.swift
+@@ -64,6 +64,7 @@ class GeneratorOptions {
+     }
+   }
+ 
++  let extraModuleImports: [String]
+   let outputNaming: OutputNaming
+   let protoToModuleMappings: ProtoFileToModuleMappings
+   let visibility: Visibility
+@@ -74,6 +75,7 @@ class GeneratorOptions {
+   let visibilitySourceSnippet: String
+ 
+   init(parameter: any CodeGeneratorParameter) throws {
++    var externalModuleImports: [String] = []
+     var outputNaming: OutputNaming = .fullPath
+     var moduleMapPath: String?
+     var visibility: Visibility = .internal
+@@ -138,6 +140,12 @@ class GeneratorOptions {
+           throw GenerationError.invalidParameterValue(name: pair.key,
+                                                       value: pair.value)
+         }
++      case "ExtraModuleImports":
++        if !pair.value.isEmpty {
++            externalModuleImports.append(pair.value)
++        } else {
++          throw GenerationError.invalidParameterValue(name: pair.key, value: pair.value)
++        }
+       default:
+         throw GenerationError.unknownParameter(name: pair.key)
+       }
+@@ -167,6 +175,7 @@ class GeneratorOptions {
+       visibilitySourceSnippet = "package "
+     }
+ 
++    self.extraModuleImports = externalModuleImports
+     self.experimentalStripNonfunctionalCodegen = experimentalStripNonfunctionalCodegen
+ 
+     switch (implementationOnlyImports, useAccessLevelOnImports) {

--- a/tests/testdata/buf.build/apple/swift/v1.28.2/eliza/plugin.sum
+++ b/tests/testdata/buf.build/apple/swift/v1.28.2/eliza/plugin.sum
@@ -1,0 +1,1 @@
+h1:2V79rqozuiAEUtD1M8yNEC0x99wWa/swFpqQzak3InA=

--- a/tests/testdata/buf.build/apple/swift/v1.28.2/petapis/plugin.sum
+++ b/tests/testdata/buf.build/apple/swift/v1.28.2/petapis/plugin.sum
@@ -1,0 +1,1 @@
+h1:uoHRiWUJ7qWsF25fxHZTCCk/O+1mLNB1KbObPI6K/pw=


### PR DESCRIPTION
Needed to fix up the patch, as the upstream adopted `swift-format`: https://github.com/apple/swift-protobuf/releases/tag/1.28.2.

Fixes #1529.