### PR TITLE
Add protocolbuffers/go v1.35.1 plugin

### DIFF
--- a/plugins/protocolbuffers/go/v1.35.1/.dockerignore
+++ b/plugins/protocolbuffers/go/v1.35.1/.dockerignore
@@ -1,0 +1,2 @@
+*
+!Dockerfile

--- a/plugins/protocolbuffers/go/v1.35.1/Dockerfile
+++ b/plugins/protocolbuffers/go/v1.35.1/Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1.10
+FROM --platform=$BUILDPLATFORM golang:1.23.2-bookworm AS build
+
+ARG TARGETOS TARGETARCH
+ENV CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH
+
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go install -ldflags "-s -w" -trimpath google.golang.org/protobuf/cmd/protoc-gen-go@v1.35.1 \
+ && mv /go/bin/${GOOS}_${GOARCH}/protoc-gen-go /go/bin/protoc-gen-go || true
+
+FROM scratch
+COPY --from=build --link /etc/passwd /etc/passwd
+COPY --from=build --link --chown=root:root /go/bin/protoc-gen-go .
+USER nobody
+ENTRYPOINT [ "/protoc-gen-go" ]

--- a/plugins/protocolbuffers/go/v1.35.1/buf.plugin.yaml
+++ b/plugins/protocolbuffers/go/v1.35.1/buf.plugin.yaml
@@ -1,0 +1,19 @@
+version: v1
+name: buf.build/protocolbuffers/go
+plugin_version: v1.35.1
+source_url: https://github.com/protocolbuffers/protobuf-go
+integration_guide_url: https://protobuf.dev/getting-started/gotutorial
+description: Base types for Go. Generates message and enum types.
+output_languages:
+  - go
+registry:
+  go:
+    # https://github.com/protocolbuffers/protobuf-go/blob/v1.35.1/go.mod#L3
+    min_version: "1.20"
+    deps:
+      - module: google.golang.org/protobuf
+        version: v1.35.1
+  opts:
+    - paths=source_relative
+spdx_license_id: BSD-3-Clause
+license_url: https://github.com/protocolbuffers/protobuf-go/blob/v1.35.1/LICENSE

--- a/plugins/protocolbuffers/go/v1.35.1/buf.plugin.yaml
+++ b/plugins/protocolbuffers/go/v1.35.1/buf.plugin.yaml
@@ -9,7 +9,7 @@ output_languages:
 registry:
   go:
     # https://github.com/protocolbuffers/protobuf-go/blob/v1.35.1/go.mod#L3
-    min_version: "1.20"
+    min_version: "1.21"
     deps:
       - module: google.golang.org/protobuf
         version: v1.35.1

--- a/tests/testdata/buf.build/protocolbuffers/go/v1.35.1/eliza/plugin.sum
+++ b/tests/testdata/buf.build/protocolbuffers/go/v1.35.1/eliza/plugin.sum
@@ -1,0 +1,1 @@
+h1:FN0txPJBdKpjYcFFsRebhhGjDoDgVdd0MVIwsVr4ppo=

--- a/tests/testdata/buf.build/protocolbuffers/go/v1.35.1/petapis/plugin.sum
+++ b/tests/testdata/buf.build/protocolbuffers/go/v1.35.1/petapis/plugin.sum
@@ -1,0 +1,1 @@
+h1:JTte37cvxS+aetNDdWt9gw+MP4I8/l+2DVn2m1LLH7A=


### PR DESCRIPTION
Needed to bump `min_version` to `1.21` after https://github.com/protocolbuffers/protobuf-go/commit/af06170887211da1ad1a291ed3b9fb1247e6680d.

Fixes #1537.