### PR TITLE
Ensure bazel server starts on IPv4 only

### DIFF
--- a/plugins/grpc/cpp/v1.67.1/Dockerfile
+++ b/plugins/grpc/cpp/v1.67.1/Dockerfile
@@ -2,6 +2,7 @@
 FROM debian:bookworm-20241016 AS build
 
 ARG TARGETARCH
+ARG BAZEL_OPTS="--host_jvm_args=-Djava.net.preferIPv4Stack=true"
 
 RUN apt-get update \
  && apt-get install -y curl git cmake build-essential autoconf clang libc++-dev libtool pkg-config unzip zip
@@ -16,8 +17,8 @@ WORKDIR /build
 
 RUN git clone --depth 1 --branch v1.67.1 https://github.com/grpc/grpc
 WORKDIR /build/grpc
-RUN bazelisk build //src/compiler:grpc_plugin_support
-RUN bazelisk build //src/compiler:grpc_cpp_plugin.stripped
+RUN bazelisk ${BAZEL_OPTS} build //src/compiler:grpc_plugin_support
+RUN bazelisk ${BAZEL_OPTS} build //src/compiler:grpc_cpp_plugin.stripped
 
 FROM gcr.io/distroless/cc-debian12:latest@sha256:6f05aba4de16e89f8d879bf2a1364de3e41aba04f1dcbba8c75494f6134b4b13 AS base
 

--- a/plugins/grpc/csharp/v1.67.1/Dockerfile
+++ b/plugins/grpc/csharp/v1.67.1/Dockerfile
@@ -2,6 +2,7 @@
 FROM debian:bookworm-20241016 AS build
 
 ARG TARGETARCH
+ARG BAZEL_OPTS="--host_jvm_args=-Djava.net.preferIPv4Stack=true"
 
 RUN apt-get update \
  && apt-get install -y curl git cmake build-essential autoconf clang libc++-dev libtool pkg-config unzip zip
@@ -16,8 +17,8 @@ WORKDIR /build
 
 RUN git clone --depth 1 --branch v1.67.1 https://github.com/grpc/grpc
 WORKDIR /build/grpc
-RUN bazelisk build //src/compiler:grpc_plugin_support
-RUN bazelisk build //src/compiler:grpc_csharp_plugin.stripped
+RUN bazelisk ${BAZEL_OPTS} build //src/compiler:grpc_plugin_support
+RUN bazelisk ${BAZEL_OPTS} build //src/compiler:grpc_csharp_plugin.stripped
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0.403-bookworm-slim@sha256:cab0284cce7bc26d41055d0ac5859a69a8b75d9a201cd226999f4f00cc983f13 AS dotnetrestore
 WORKDIR /build

--- a/plugins/grpc/objc/v1.67.1/Dockerfile
+++ b/plugins/grpc/objc/v1.67.1/Dockerfile
@@ -2,6 +2,7 @@
 FROM debian:bookworm-20241016 AS build
 
 ARG TARGETARCH
+ARG BAZEL_OPTS="--host_jvm_args=-Djava.net.preferIPv4Stack=true"
 
 RUN apt-get update \
  && apt-get install -y curl git cmake build-essential autoconf clang libc++-dev libtool pkg-config unzip zip
@@ -16,8 +17,8 @@ WORKDIR /build
 
 RUN git clone --depth 1 --branch v1.67.1 https://github.com/grpc/grpc
 WORKDIR /build/grpc
-RUN bazelisk build //src/compiler:grpc_plugin_support
-RUN bazelisk build //src/compiler:grpc_objective_c_plugin.stripped
+RUN bazelisk ${BAZEL_OPTS} build //src/compiler:grpc_plugin_support
+RUN bazelisk ${BAZEL_OPTS} build //src/compiler:grpc_objective_c_plugin.stripped
 
 FROM gcr.io/distroless/cc-debian12:latest@sha256:6f05aba4de16e89f8d879bf2a1364de3e41aba04f1dcbba8c75494f6134b4b13 AS base
 

--- a/plugins/grpc/php/v1.67.1/Dockerfile
+++ b/plugins/grpc/php/v1.67.1/Dockerfile
@@ -2,6 +2,7 @@
 FROM debian:bookworm-20241016 AS build
 
 ARG TARGETARCH
+ARG BAZEL_OPTS="--host_jvm_args=-Djava.net.preferIPv4Stack=true"
 
 RUN apt-get update \
  && apt-get install -y curl git cmake build-essential autoconf clang libc++-dev libtool pkg-config unzip zip
@@ -16,8 +17,8 @@ WORKDIR /build
 
 RUN git clone --depth 1 --branch v1.67.1 https://github.com/grpc/grpc
 WORKDIR /build/grpc
-RUN bazelisk build //src/compiler:grpc_plugin_support
-RUN bazelisk build //src/compiler:grpc_php_plugin.stripped
+RUN bazelisk ${BAZEL_OPTS} build //src/compiler:grpc_plugin_support
+RUN bazelisk ${BAZEL_OPTS} build //src/compiler:grpc_php_plugin.stripped
 
 FROM gcr.io/distroless/cc-debian12:latest@sha256:6f05aba4de16e89f8d879bf2a1364de3e41aba04f1dcbba8c75494f6134b4b13 AS base
 

--- a/plugins/grpc/python/v1.67.1/Dockerfile
+++ b/plugins/grpc/python/v1.67.1/Dockerfile
@@ -2,6 +2,7 @@
 FROM debian:bookworm-20241016 AS build
 
 ARG TARGETARCH
+ARG BAZEL_OPTS="--host_jvm_args=-Djava.net.preferIPv4Stack=true"
 
 RUN apt-get update \
  && apt-get install -y curl git cmake build-essential autoconf clang libc++-dev libtool pkg-config unzip zip
@@ -16,8 +17,8 @@ WORKDIR /build
 
 RUN git clone --depth 1 --branch v1.67.1 https://github.com/grpc/grpc
 WORKDIR /build/grpc
-RUN bazelisk build //src/compiler:grpc_plugin_support
-RUN bazelisk build //src/compiler:grpc_python_plugin.stripped
+RUN bazelisk ${BAZEL_OPTS} build //src/compiler:grpc_plugin_support
+RUN bazelisk ${BAZEL_OPTS} build //src/compiler:grpc_python_plugin.stripped
 
 FROM gcr.io/distroless/cc-debian12:latest@sha256:6f05aba4de16e89f8d879bf2a1364de3e41aba04f1dcbba8c75494f6134b4b13 AS base
 

--- a/plugins/grpc/ruby/v1.67.1/Dockerfile
+++ b/plugins/grpc/ruby/v1.67.1/Dockerfile
@@ -2,6 +2,7 @@
 FROM debian:bookworm-20241016 AS build
 
 ARG TARGETARCH
+ARG BAZEL_OPTS="--host_jvm_args=-Djava.net.preferIPv4Stack=true"
 
 RUN apt-get update \
  && apt-get install -y curl git cmake build-essential autoconf clang libc++-dev libtool pkg-config unzip zip
@@ -16,8 +17,8 @@ WORKDIR /build
 
 RUN git clone --depth 1 --branch v1.67.1 https://github.com/grpc/grpc
 WORKDIR /build/grpc
-RUN bazelisk build //src/compiler:grpc_plugin_support
-RUN bazelisk build //src/compiler:grpc_ruby_plugin.stripped
+RUN bazelisk ${BAZEL_OPTS} build //src/compiler:grpc_plugin_support
+RUN bazelisk ${BAZEL_OPTS} build //src/compiler:grpc_ruby_plugin.stripped
 
 FROM gcr.io/distroless/cc-debian12:latest@sha256:6f05aba4de16e89f8d879bf2a1364de3e41aba04f1dcbba8c75494f6134b4b13 AS base
 


### PR DESCRIPTION
When building on macOS with the docker-container driver, there are errors connecting between the server and client used internally by bazel. It appears that the server binds to `[::1]:0` and the client for some reason can't connect.

Update to specify that the server should prefer IPv4 over IPv6 addresses, which appears to resolve the issue.