### PR TITLE
Update protoc build to use bazelisk

### DIFF
--- a/plugins/protocolbuffers/cpp/v28.3/Dockerfile
+++ b/plugins/protocolbuffers/cpp/v28.3/Dockerfile
@@ -2,21 +2,24 @@
 FROM debian:bookworm-20241016 AS build
 
 ARG TARGETARCH
+ARG BAZEL_OPTS="--host_jvm_args=-Djava.net.preferIPv4Stack=true"
 
 RUN apt-get update \
- && apt-get install -y curl git cmake build-essential g++ unzip zip
-RUN arch=${TARGETARCH}; \
-    if [ "${arch}" = "amd64" ]; then arch="x86_64"; fi; \
-    curl -fsSL -o /usr/local/bin/bazel https://github.com/bazelbuild/bazel/releases/download/7.4.0/bazel-7.4.0-linux-${arch} \
- && chmod +x /usr/local/bin/bazel
+ && apt-get install -y curl git cmake build-essential autoconf clang libc++-dev libtool pkg-config unzip zip
+RUN curl -fsSL -o /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.23.0/bazelisk-linux-${TARGETARCH} \
+ && chmod +x /usr/local/bin/bazelisk \
+ && mkdir /build \
+ && chown nobody:nogroup /build \
+ && usermod --home /build nobody
 
+USER nobody
 WORKDIR /build
 RUN curl -fsSL -o protoc.tar.gz https://github.com/protocolbuffers/protobuf/releases/download/v28.3/protobuf-28.3.tar.gz \
  && tar --strip-components=1 -zxf protoc.tar.gz \
  && rm protoc.tar.gz
-RUN bazel build '//:protoc_lib'
+RUN bazelisk ${BAZEL_OPTS} build '//:protoc_lib'
 COPY --link BUILD cpp.cc plugins/
-RUN bazel build '//plugins:protoc-gen-cpp.stripped'
+RUN bazelisk ${BAZEL_OPTS} build '//plugins:protoc-gen-cpp.stripped'
 
 FROM gcr.io/distroless/cc-debian12:latest@sha256:3310655aac0d85eb9d579792387af1ff3eb7a1667823478be58020ab0e0d97a8 AS base
 

--- a/plugins/protocolbuffers/csharp/v28.3/Dockerfile
+++ b/plugins/protocolbuffers/csharp/v28.3/Dockerfile
@@ -2,21 +2,24 @@
 FROM debian:bookworm-20241016 AS build
 
 ARG TARGETARCH
+ARG BAZEL_OPTS="--host_jvm_args=-Djava.net.preferIPv4Stack=true"
 
 RUN apt-get update \
- && apt-get install -y curl git cmake build-essential g++ unzip zip
-RUN arch=${TARGETARCH}; \
-    if [ "${arch}" = "amd64" ]; then arch="x86_64"; fi; \
-    curl -fsSL -o /usr/local/bin/bazel https://github.com/bazelbuild/bazel/releases/download/7.4.0/bazel-7.4.0-linux-${arch} \
- && chmod +x /usr/local/bin/bazel
+ && apt-get install -y curl git cmake build-essential autoconf clang libc++-dev libtool pkg-config unzip zip
+RUN curl -fsSL -o /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.23.0/bazelisk-linux-${TARGETARCH} \
+ && chmod +x /usr/local/bin/bazelisk \
+ && mkdir /build \
+ && chown nobody:nogroup /build \
+ && usermod --home /build nobody
 
+USER nobody
 WORKDIR /build
 RUN curl -fsSL -o protoc.tar.gz https://github.com/protocolbuffers/protobuf/releases/download/v28.3/protobuf-28.3.tar.gz \
  && tar --strip-components=1 -zxf protoc.tar.gz \
  && rm protoc.tar.gz
-RUN bazel build '//:protoc_lib'
+RUN bazelisk ${BAZEL_OPTS} build '//:protoc_lib'
 COPY --link BUILD csharp.cc plugins/
-RUN bazel build '//plugins:protoc-gen-csharp.stripped'
+RUN bazelisk ${BAZEL_OPTS} build '//plugins:protoc-gen-csharp.stripped'
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0.403-bookworm-slim@sha256:cab0284cce7bc26d41055d0ac5859a69a8b75d9a201cd226999f4f00cc983f13 AS dotnetrestore
 WORKDIR /build

--- a/plugins/protocolbuffers/java/v28.3/Dockerfile
+++ b/plugins/protocolbuffers/java/v28.3/Dockerfile
@@ -2,21 +2,24 @@
 FROM debian:bookworm-20241016 AS build
 
 ARG TARGETARCH
+ARG BAZEL_OPTS="--host_jvm_args=-Djava.net.preferIPv4Stack=true"
 
 RUN apt-get update \
- && apt-get install -y curl git cmake build-essential g++ unzip zip
-RUN arch=${TARGETARCH}; \
-    if [ "${arch}" = "amd64" ]; then arch="x86_64"; fi; \
-    curl -fsSL -o /usr/local/bin/bazel https://github.com/bazelbuild/bazel/releases/download/7.4.0/bazel-7.4.0-linux-${arch} \
- && chmod +x /usr/local/bin/bazel
+ && apt-get install -y curl git cmake build-essential autoconf clang libc++-dev libtool pkg-config unzip zip
+RUN curl -fsSL -o /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.23.0/bazelisk-linux-${TARGETARCH} \
+ && chmod +x /usr/local/bin/bazelisk \
+ && mkdir /build \
+ && chown nobody:nogroup /build \
+ && usermod --home /build nobody
 
+USER nobody
 WORKDIR /build
 RUN curl -fsSL -o protoc.tar.gz https://github.com/protocolbuffers/protobuf/releases/download/v28.3/protobuf-28.3.tar.gz \
  && tar --strip-components=1 -zxf protoc.tar.gz \
  && rm protoc.tar.gz
-RUN bazel build '//:protoc_lib'
+RUN bazelisk ${BAZEL_OPTS} build '//:protoc_lib'
 COPY --link BUILD java.cc plugins/
-RUN bazel build '//plugins:protoc-gen-java.stripped'
+RUN bazelisk ${BAZEL_OPTS} build '//plugins:protoc-gen-java.stripped'
 
 FROM gcr.io/distroless/cc-debian12:latest@sha256:3310655aac0d85eb9d579792387af1ff3eb7a1667823478be58020ab0e0d97a8 AS base
 

--- a/plugins/protocolbuffers/kotlin/v28.3/Dockerfile
+++ b/plugins/protocolbuffers/kotlin/v28.3/Dockerfile
@@ -2,21 +2,24 @@
 FROM debian:bookworm-20241016 AS build
 
 ARG TARGETARCH
+ARG BAZEL_OPTS="--host_jvm_args=-Djava.net.preferIPv4Stack=true"
 
 RUN apt-get update \
- && apt-get install -y curl git cmake build-essential g++ unzip zip
-RUN arch=${TARGETARCH}; \
-    if [ "${arch}" = "amd64" ]; then arch="x86_64"; fi; \
-    curl -fsSL -o /usr/local/bin/bazel https://github.com/bazelbuild/bazel/releases/download/7.4.0/bazel-7.4.0-linux-${arch} \
- && chmod +x /usr/local/bin/bazel
+ && apt-get install -y curl git cmake build-essential autoconf clang libc++-dev libtool pkg-config unzip zip
+RUN curl -fsSL -o /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.23.0/bazelisk-linux-${TARGETARCH} \
+ && chmod +x /usr/local/bin/bazelisk \
+ && mkdir /build \
+ && chown nobody:nogroup /build \
+ && usermod --home /build nobody
 
+USER nobody
 WORKDIR /build
 RUN curl -fsSL -o protoc.tar.gz https://github.com/protocolbuffers/protobuf/releases/download/v28.3/protobuf-28.3.tar.gz \
  && tar --strip-components=1 -zxf protoc.tar.gz \
  && rm protoc.tar.gz
-RUN bazel build '//:protoc_lib'
+RUN bazelisk ${BAZEL_OPTS} build '//:protoc_lib'
 COPY --link BUILD kotlin.cc plugins/
-RUN bazel build '//plugins:protoc-gen-kotlin.stripped'
+RUN bazelisk ${BAZEL_OPTS} build '//plugins:protoc-gen-kotlin.stripped'
 
 FROM gcr.io/distroless/cc-debian12:latest@sha256:3310655aac0d85eb9d579792387af1ff3eb7a1667823478be58020ab0e0d97a8 AS base
 

--- a/plugins/protocolbuffers/objc/v28.3/Dockerfile
+++ b/plugins/protocolbuffers/objc/v28.3/Dockerfile
@@ -2,21 +2,24 @@
 FROM debian:bookworm-20241016 AS build
 
 ARG TARGETARCH
+ARG BAZEL_OPTS="--host_jvm_args=-Djava.net.preferIPv4Stack=true"
 
 RUN apt-get update \
- && apt-get install -y curl git cmake build-essential g++ unzip zip
-RUN arch=${TARGETARCH}; \
-    if [ "${arch}" = "amd64" ]; then arch="x86_64"; fi; \
-    curl -fsSL -o /usr/local/bin/bazel https://github.com/bazelbuild/bazel/releases/download/7.4.0/bazel-7.4.0-linux-${arch} \
- && chmod +x /usr/local/bin/bazel
+ && apt-get install -y curl git cmake build-essential autoconf clang libc++-dev libtool pkg-config unzip zip
+RUN curl -fsSL -o /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.23.0/bazelisk-linux-${TARGETARCH} \
+ && chmod +x /usr/local/bin/bazelisk \
+ && mkdir /build \
+ && chown nobody:nogroup /build \
+ && usermod --home /build nobody
 
+USER nobody
 WORKDIR /build
 RUN curl -fsSL -o protoc.tar.gz https://github.com/protocolbuffers/protobuf/releases/download/v28.3/protobuf-28.3.tar.gz \
  && tar --strip-components=1 -zxf protoc.tar.gz \
  && rm protoc.tar.gz
-RUN bazel build '//:protoc_lib'
+RUN bazelisk ${BAZEL_OPTS} build '//:protoc_lib'
 COPY --link BUILD objectivec.cc plugins/
-RUN bazel build '//plugins:protoc-gen-objectivec.stripped'
+RUN bazelisk ${BAZEL_OPTS} build '//plugins:protoc-gen-objectivec.stripped'
 
 FROM gcr.io/distroless/cc-debian12:latest@sha256:3310655aac0d85eb9d579792387af1ff3eb7a1667823478be58020ab0e0d97a8 AS base
 

--- a/plugins/protocolbuffers/php/v28.3/Dockerfile
+++ b/plugins/protocolbuffers/php/v28.3/Dockerfile
@@ -2,21 +2,24 @@
 FROM debian:bookworm-20241016 AS build
 
 ARG TARGETARCH
+ARG BAZEL_OPTS="--host_jvm_args=-Djava.net.preferIPv4Stack=true"
 
 RUN apt-get update \
- && apt-get install -y curl git cmake build-essential g++ unzip zip
-RUN arch=${TARGETARCH}; \
-    if [ "${arch}" = "amd64" ]; then arch="x86_64"; fi; \
-    curl -fsSL -o /usr/local/bin/bazel https://github.com/bazelbuild/bazel/releases/download/7.4.0/bazel-7.4.0-linux-${arch} \
- && chmod +x /usr/local/bin/bazel
+ && apt-get install -y curl git cmake build-essential autoconf clang libc++-dev libtool pkg-config unzip zip
+RUN curl -fsSL -o /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.23.0/bazelisk-linux-${TARGETARCH} \
+ && chmod +x /usr/local/bin/bazelisk \
+ && mkdir /build \
+ && chown nobody:nogroup /build \
+ && usermod --home /build nobody
 
+USER nobody
 WORKDIR /build
 RUN curl -fsSL -o protoc.tar.gz https://github.com/protocolbuffers/protobuf/releases/download/v28.3/protobuf-28.3.tar.gz \
  && tar --strip-components=1 -zxf protoc.tar.gz \
  && rm protoc.tar.gz
-RUN bazel build '//:protoc_lib'
+RUN bazelisk ${BAZEL_OPTS} build '//:protoc_lib'
 COPY --link BUILD php.cc plugins/
-RUN bazel build '//plugins:protoc-gen-php.stripped'
+RUN bazelisk ${BAZEL_OPTS} build '//plugins:protoc-gen-php.stripped'
 
 FROM gcr.io/distroless/cc-debian12:latest@sha256:3310655aac0d85eb9d579792387af1ff3eb7a1667823478be58020ab0e0d97a8 AS base
 

--- a/plugins/protocolbuffers/pyi/v28.3/Dockerfile
+++ b/plugins/protocolbuffers/pyi/v28.3/Dockerfile
@@ -2,21 +2,24 @@
 FROM debian:bookworm-20241016 AS build
 
 ARG TARGETARCH
+ARG BAZEL_OPTS="--host_jvm_args=-Djava.net.preferIPv4Stack=true"
 
 RUN apt-get update \
- && apt-get install -y curl git cmake build-essential g++ unzip zip
-RUN arch=${TARGETARCH}; \
-    if [ "${arch}" = "amd64" ]; then arch="x86_64"; fi; \
-    curl -fsSL -o /usr/local/bin/bazel https://github.com/bazelbuild/bazel/releases/download/7.4.0/bazel-7.4.0-linux-${arch} \
- && chmod +x /usr/local/bin/bazel
+ && apt-get install -y curl git cmake build-essential autoconf clang libc++-dev libtool pkg-config unzip zip
+RUN curl -fsSL -o /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.23.0/bazelisk-linux-${TARGETARCH} \
+ && chmod +x /usr/local/bin/bazelisk \
+ && mkdir /build \
+ && chown nobody:nogroup /build \
+ && usermod --home /build nobody
 
+USER nobody
 WORKDIR /build
 RUN curl -fsSL -o protoc.tar.gz https://github.com/protocolbuffers/protobuf/releases/download/v28.3/protobuf-28.3.tar.gz \
  && tar --strip-components=1 -zxf protoc.tar.gz \
  && rm protoc.tar.gz
-RUN bazel build '//:protoc_lib'
+RUN bazelisk ${BAZEL_OPTS} build '//:protoc_lib'
 COPY BUILD pyi.cc plugins/
-RUN bazel build '//plugins:protoc-gen-pyi.stripped'
+RUN bazelisk ${BAZEL_OPTS} build '//plugins:protoc-gen-pyi.stripped'
 
 FROM gcr.io/distroless/cc-debian12:latest@sha256:3310655aac0d85eb9d579792387af1ff3eb7a1667823478be58020ab0e0d97a8 AS base
 

--- a/plugins/protocolbuffers/python/v28.3/Dockerfile
+++ b/plugins/protocolbuffers/python/v28.3/Dockerfile
@@ -2,21 +2,24 @@
 FROM debian:bookworm-20241016 AS build
 
 ARG TARGETARCH
+ARG BAZEL_OPTS="--host_jvm_args=-Djava.net.preferIPv4Stack=true"
 
 RUN apt-get update \
- && apt-get install -y curl git cmake build-essential g++ unzip zip
-RUN arch=${TARGETARCH}; \
-    if [ "${arch}" = "amd64" ]; then arch="x86_64"; fi; \
-    curl -fsSL -o /usr/local/bin/bazel https://github.com/bazelbuild/bazel/releases/download/7.4.0/bazel-7.4.0-linux-${arch} \
- && chmod +x /usr/local/bin/bazel
+ && apt-get install -y curl git cmake build-essential autoconf clang libc++-dev libtool pkg-config unzip zip
+RUN curl -fsSL -o /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.23.0/bazelisk-linux-${TARGETARCH} \
+ && chmod +x /usr/local/bin/bazelisk \
+ && mkdir /build \
+ && chown nobody:nogroup /build \
+ && usermod --home /build nobody
 
+USER nobody
 WORKDIR /build
 RUN curl -fsSL -o protoc.tar.gz https://github.com/protocolbuffers/protobuf/releases/download/v28.3/protobuf-28.3.tar.gz \
  && tar --strip-components=1 -zxf protoc.tar.gz \
  && rm protoc.tar.gz
-RUN bazel build '//:protoc_lib'
+RUN bazelisk ${BAZEL_OPTS} build '//:protoc_lib'
 COPY --link BUILD python.cc plugins/
-RUN bazel build '//plugins:protoc-gen-python.stripped'
+RUN bazelisk ${BAZEL_OPTS} build '//plugins:protoc-gen-python.stripped'
 
 FROM gcr.io/distroless/cc-debian12:latest@sha256:3310655aac0d85eb9d579792387af1ff3eb7a1667823478be58020ab0e0d97a8 AS base
 

--- a/plugins/protocolbuffers/ruby/v28.3/Dockerfile
+++ b/plugins/protocolbuffers/ruby/v28.3/Dockerfile
@@ -2,21 +2,24 @@
 FROM debian:bookworm-20241016 AS build
 
 ARG TARGETARCH
+ARG BAZEL_OPTS="--host_jvm_args=-Djava.net.preferIPv4Stack=true"
 
 RUN apt-get update \
- && apt-get install -y curl git cmake build-essential g++ unzip zip
-RUN arch=${TARGETARCH}; \
-    if [ "${arch}" = "amd64" ]; then arch="x86_64"; fi; \
-    curl -fsSL -o /usr/local/bin/bazel https://github.com/bazelbuild/bazel/releases/download/7.4.0/bazel-7.4.0-linux-${arch} \
- && chmod +x /usr/local/bin/bazel
+ && apt-get install -y curl git cmake build-essential autoconf clang libc++-dev libtool pkg-config unzip zip
+RUN curl -fsSL -o /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.23.0/bazelisk-linux-${TARGETARCH} \
+ && chmod +x /usr/local/bin/bazelisk \
+ && mkdir /build \
+ && chown nobody:nogroup /build \
+ && usermod --home /build nobody
 
+USER nobody
 WORKDIR /build
 RUN curl -fsSL -o protoc.tar.gz https://github.com/protocolbuffers/protobuf/releases/download/v28.3/protobuf-28.3.tar.gz \
  && tar --strip-components=1 -zxf protoc.tar.gz \
  && rm protoc.tar.gz
-RUN bazel build '//:protoc_lib'
+RUN bazelisk ${BAZEL_OPTS} build '//:protoc_lib'
 COPY --link BUILD ruby.cc plugins/
-RUN bazel build '//plugins:protoc-gen-ruby.stripped'
+RUN bazelisk ${BAZEL_OPTS} build '//plugins:protoc-gen-ruby.stripped'
 
 FROM gcr.io/distroless/cc-debian12:latest@sha256:3310655aac0d85eb9d579792387af1ff3eb7a1667823478be58020ab0e0d97a8 AS base
 


### PR DESCRIPTION
Update protoc plugin builds to use bazelisk, run as non-root, and apply a workaround for bazel builds on macOS.