### PR TITLE
Bump `protocolbuffers/csharp@28.3` to `netstandard2.0`

### DIFF
--- a/plugins/protocolbuffers/csharp/v28.3/buf.plugin.yaml
+++ b/plugins/protocolbuffers/csharp/v28.3/buf.plugin.yaml
@@ -12,7 +12,7 @@ registry:
     - base_namespace=
   nuget:
     target_frameworks:
-      - netstandard1.1
+      - netstandard2.0
     deps:
       - name: Google.Protobuf
         version: 3.28.3

--- a/plugins/protocolbuffers/csharp/v28.3/build.csproj
+++ b/plugins/protocolbuffers/csharp/v28.3/build.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.28.3" />


### PR DESCRIPTION
.NET 9 SDK [raises](https://learn.microsoft.com/en-ca/dotnet/core/compatibility/sdk/9.0/netstandard-warning) a (suppressable) build warning about this, largely to encourage developers to upgrade. This should not be an issue for consumers, as the more important consideration is the hosting application's target framework.

More importantly, using `netstandard1.1` results in a vulnerable version of `System.Net.Http` being pulled in (`4.3.0`) via `Google.Protobuf`'s `netstandard1.1` deps. Upgrading to `netstandard2.0` resolves this.

`grpc/csharp` is already using `netstandard2.0`. No other C# plugins exist.