### PR TITLE
Deprecate connectrpc es and query-es

### DIFF
--- a/plugins/bufbuild/connect-es/v0.13.0/buf.plugin.yaml
+++ b/plugins/bufbuild/connect-es/v0.13.0/buf.plugin.yaml
@@ -2,7 +2,7 @@ version: v1
 name: buf.build/bufbuild/connect-es
 plugin_version: v0.13.0
 source_url: https://github.com/bufbuild/connect-es
-description: Generates code that is compatible with browsers and Node.js for working with Connect, gRPC, and gRPC-Web.
+description: Generates code that is compatible with browsers and Node.js for working with Connect, gRPC, and gRPC-Web. This plugin is deprecated because it has moved to the connectrpc org.
 deps:
   - plugin: buf.build/bufbuild/es:v1.3.0
 output_languages:

--- a/plugins/bufbuild/connect-query/v0.4.1/buf.plugin.yaml
+++ b/plugins/bufbuild/connect-query/v0.4.1/buf.plugin.yaml
@@ -2,7 +2,7 @@ version: v1
 name: buf.build/bufbuild/connect-query
 plugin_version: v0.4.1
 source_url: https://github.com/bufbuild/connect-query
-description: Generates client stubs for calling Connect services with TanStack Query.
+description: Generates client stubs for calling Connect services with TanStack Query. This plugin is deprecated because it has moved to the connectrpc org.
 deps:
   - plugin: buf.build/bufbuild/es:v1.3.0
 output_languages:

--- a/plugins/bufbuild/es/v2.2.2/buf.plugin.yaml
+++ b/plugins/bufbuild/es/v2.2.2/buf.plugin.yaml
@@ -3,7 +3,7 @@ name: buf.build/bufbuild/es
 plugin_version: v2.2.2
 source_url: https://github.com/bufbuild/protobuf-es
 integration_guide_url: https://github.com/bufbuild/protobuf-es#quickstart
-description: Base types for TypeScript/JavaScript for use in web browsers and Node.js. Generates message and enum types.
+description: Types for TypeScript/JavaScript for use in web browsers and Node.js. Generates message and enum types, but also services for use with Connect v2.
 output_languages:
   - javascript
   - typescript

--- a/plugins/connectrpc/es/v1.6.1/buf.plugin.yaml
+++ b/plugins/connectrpc/es/v1.6.1/buf.plugin.yaml
@@ -3,7 +3,7 @@ name: buf.build/connectrpc/es
 plugin_version: v1.6.1
 source_url: https://github.com/connectrpc/connect-es
 integration_guide_url: https://connectrpc.com/docs/web/getting-started
-description: Generates code that is compatible with browsers and Node.js for working with Connect, gRPC, and gRPC-Web.
+description: Generates code that is compatible with browsers and Node.js for working with Connect, gRPC, and gRPC-Web. This plugin is deprecated, see [Migration Guide](https://github.com/connectrpc/connect-es/blob/v2.0.0/MIGRATING.md) to upgrade to the latest version.
 deps:
   - plugin: buf.build/bufbuild/es:v1.10.0
 output_languages:
@@ -18,3 +18,4 @@ registry:
         version: ^1.6.1
 spdx_license_id: Apache-2.0
 license_url: https://github.com/connectrpc/connect-es/blob/v1.6.1/LICENSE
+deprecated: true

--- a/plugins/connectrpc/es/v1.6.1/buf.plugin.yaml
+++ b/plugins/connectrpc/es/v1.6.1/buf.plugin.yaml
@@ -3,7 +3,7 @@ name: buf.build/connectrpc/es
 plugin_version: v1.6.1
 source_url: https://github.com/connectrpc/connect-es
 integration_guide_url: https://connectrpc.com/docs/web/getting-started
-description: Generates code that is compatible with browsers and Node.js for working with Connect, gRPC, and gRPC-Web. This plugin is deprecated, see [Migration Guide](https://github.com/connectrpc/connect-es/blob/v2.0.0/MIGRATING.md) to upgrade to the latest version.
+description: Generates code that is compatible with browsers and Node.js for working with Connect, gRPC, and gRPC-Web. This plugin is for Connect-ES v1. For Connect-ES v2, you'll only need the bufbuild/es plugin. See see [Migration Guide](https://github.com/connectrpc/connect-es/blob/v2.0.0/MIGRATING.md) for details.
 deps:
   - plugin: buf.build/bufbuild/es:v1.10.0
 output_languages:

--- a/plugins/connectrpc/es/v1.6.1/buf.plugin.yaml
+++ b/plugins/connectrpc/es/v1.6.1/buf.plugin.yaml
@@ -3,7 +3,7 @@ name: buf.build/connectrpc/es
 plugin_version: v1.6.1
 source_url: https://github.com/connectrpc/connect-es
 integration_guide_url: https://connectrpc.com/docs/web/getting-started
-description: Generates code that is compatible with browsers and Node.js for working with Connect, gRPC, and gRPC-Web. This plugin is for Connect-ES v1. For Connect-ES v2, you'll only need the bufbuild/es plugin. See see [Migration Guide](https://github.com/connectrpc/connect-es/blob/v2.0.0/MIGRATING.md) for details.
+description: Generates code that is compatible with browsers and Node.js for working with Connect, gRPC, and gRPC-Web. This plugin is for Connect-ES v1. For Connect-ES v2, you'll only need the bufbuild/es plugin.
 deps:
   - plugin: buf.build/bufbuild/es:v1.10.0
 output_languages:

--- a/plugins/connectrpc/query-es/v1.4.2/buf.plugin.yaml
+++ b/plugins/connectrpc/query-es/v1.4.2/buf.plugin.yaml
@@ -3,7 +3,7 @@ name: buf.build/connectrpc/query-es
 plugin_version: v1.4.2
 source_url: https://github.com/connectrpc/connect-query-es
 integration_guide_url: https://connectrpc.com/docs/web/query/getting-started
-description: Generates client stubs for calling Connect services with TanStack Query.
+description: Generates client stubs for calling Connect services with TanStack Query. This plugin is deprecated, see [Migration Guide](https://github.com/connectrpc/connect-es/blob/v2.0.0/MIGRATING.md) to upgrade to the latest version.
 deps:
   - plugin: buf.build/bufbuild/es:v1.10.0
 output_languages:
@@ -20,3 +20,4 @@ registry:
         version: ^v1.10.0
 spdx_license_id: Apache-2.0
 license_url: https://github.com/connectrpc/connect-query-es/blob/v1.4.2/LICENSE
+deprecated: true

--- a/plugins/connectrpc/query-es/v1.4.2/buf.plugin.yaml
+++ b/plugins/connectrpc/query-es/v1.4.2/buf.plugin.yaml
@@ -3,7 +3,7 @@ name: buf.build/connectrpc/query-es
 plugin_version: v1.4.2
 source_url: https://github.com/connectrpc/connect-query-es
 integration_guide_url: https://connectrpc.com/docs/web/query/getting-started
-description: Generates client stubs for calling Connect services with TanStack Query. This plugin is for Connect-ES v1. For Connect-ES v2, you'll only need the bufbuild/es plugin. See see [Migration Guide](https://github.com/connectrpc/connect-es/blob/v2.0.0/MIGRATING.md) for details.
+description: Generates client stubs for calling Connect services with TanStack Query. This plugin is for Connect-ES v1. For Connect-ES v2, you'll only need the bufbuild/es plugin.
 deps:
   - plugin: buf.build/bufbuild/es:v1.10.0
 output_languages:

--- a/plugins/connectrpc/query-es/v1.4.2/buf.plugin.yaml
+++ b/plugins/connectrpc/query-es/v1.4.2/buf.plugin.yaml
@@ -3,7 +3,7 @@ name: buf.build/connectrpc/query-es
 plugin_version: v1.4.2
 source_url: https://github.com/connectrpc/connect-query-es
 integration_guide_url: https://connectrpc.com/docs/web/query/getting-started
-description: Generates client stubs for calling Connect services with TanStack Query. This plugin is deprecated, see [Migration Guide](https://github.com/connectrpc/connect-es/blob/v2.0.0/MIGRATING.md) to upgrade to the latest version.
+description: Generates client stubs for calling Connect services with TanStack Query. This plugin is for Connect-ES v1. For Connect-ES v2, you'll only need the bufbuild/es plugin. See see [Migration Guide](https://github.com/connectrpc/connect-es/blob/v2.0.0/MIGRATING.md) for details.
 deps:
   - plugin: buf.build/bufbuild/es:v1.10.0
 output_languages:


### PR DESCRIPTION
This PR marks the following plugins as deprecated with a new description:

- https://buf.build/connectrpc/es
- https://buf.build/connectrpc/query-es

And updates the description for:

- https://buf.build/bufbuild/connect-es (previously deprecated)
- https://buf.build/bufbuild/connect-query (previously deprecated)
- https://github.com/bufbuild/protobuf-es

After this is merged/released, I'll make them as `disabled: true` in the source. I don't recall if we use that for any logic outside the fetcher.