### PR TITLE
Disable protoc-gen-bq-schema sync

### DIFF
--- a/plugins/googlecloudplatform/bq-schema/source.yaml
+++ b/plugins/googlecloudplatform/bq-schema/source.yaml
@@ -1,4 +1,5 @@
 source:
+  disabled: true
   github:
     owner: GoogleCloudPlatform
     repository: protoc-gen-bq-schema

--- a/plugins/googlecloudplatform/bq-schema/source.yaml
+++ b/plugins/googlecloudplatform/bq-schema/source.yaml
@@ -1,4 +1,6 @@
 source:
+  # Disabled until we have a proper release
+  # See: https://github.com/GoogleCloudPlatform/protoc-gen-bq-schema/pull/52
   disabled: true
   github:
     owner: GoogleCloudPlatform


### PR DESCRIPTION
Temporarily disable this plugin until we hear back on https://github.com/GoogleCloudPlatform/protoc-gen-bq-schema/pull/52

Would like to get the fetcher job green.