### PR TITLE
Pin bazel version for reproducible builds

### DIFF
--- a/plugins/protocolbuffers/cpp/v28.3/Dockerfile
+++ b/plugins/protocolbuffers/cpp/v28.3/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.10
 FROM debian:bookworm-20241016 AS build
 
+ENV USE_BAZEL_VERSION=7.4.1
 ARG TARGETARCH
 ARG BAZEL_OPTS="--host_jvm_args=-Djava.net.preferIPv4Stack=true"
 

--- a/plugins/protocolbuffers/csharp/v28.3/Dockerfile
+++ b/plugins/protocolbuffers/csharp/v28.3/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.10
 FROM debian:bookworm-20241016 AS build
 
+ENV USE_BAZEL_VERSION=7.4.1
 ARG TARGETARCH
 ARG BAZEL_OPTS="--host_jvm_args=-Djava.net.preferIPv4Stack=true"
 

--- a/plugins/protocolbuffers/java/v28.3/Dockerfile
+++ b/plugins/protocolbuffers/java/v28.3/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.10
 FROM debian:bookworm-20241016 AS build
 
+ENV USE_BAZEL_VERSION=7.4.1
 ARG TARGETARCH
 ARG BAZEL_OPTS="--host_jvm_args=-Djava.net.preferIPv4Stack=true"
 

--- a/plugins/protocolbuffers/kotlin/v28.3/Dockerfile
+++ b/plugins/protocolbuffers/kotlin/v28.3/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.10
 FROM debian:bookworm-20241016 AS build
 
+ENV USE_BAZEL_VERSION=7.4.1
 ARG TARGETARCH
 ARG BAZEL_OPTS="--host_jvm_args=-Djava.net.preferIPv4Stack=true"
 

--- a/plugins/protocolbuffers/objc/v28.3/Dockerfile
+++ b/plugins/protocolbuffers/objc/v28.3/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.10
 FROM debian:bookworm-20241016 AS build
 
+ENV USE_BAZEL_VERSION=7.4.1
 ARG TARGETARCH
 ARG BAZEL_OPTS="--host_jvm_args=-Djava.net.preferIPv4Stack=true"
 

--- a/plugins/protocolbuffers/php/v28.3/Dockerfile
+++ b/plugins/protocolbuffers/php/v28.3/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.10
 FROM debian:bookworm-20241016 AS build
 
+ENV USE_BAZEL_VERSION=7.4.1
 ARG TARGETARCH
 ARG BAZEL_OPTS="--host_jvm_args=-Djava.net.preferIPv4Stack=true"
 

--- a/plugins/protocolbuffers/pyi/v28.3/Dockerfile
+++ b/plugins/protocolbuffers/pyi/v28.3/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.10
 FROM debian:bookworm-20241016 AS build
 
+ENV USE_BAZEL_VERSION=7.4.1
 ARG TARGETARCH
 ARG BAZEL_OPTS="--host_jvm_args=-Djava.net.preferIPv4Stack=true"
 

--- a/plugins/protocolbuffers/python/v28.3/Dockerfile
+++ b/plugins/protocolbuffers/python/v28.3/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.10
 FROM debian:bookworm-20241016 AS build
 
+ENV USE_BAZEL_VERSION=7.4.1
 ARG TARGETARCH
 ARG BAZEL_OPTS="--host_jvm_args=-Djava.net.preferIPv4Stack=true"
 

--- a/plugins/protocolbuffers/ruby/v28.3/Dockerfile
+++ b/plugins/protocolbuffers/ruby/v28.3/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.10
 FROM debian:bookworm-20241016 AS build
 
+ENV USE_BAZEL_VERSION=7.4.1
 ARG TARGETARCH
 ARG BAZEL_OPTS="--host_jvm_args=-Djava.net.preferIPv4Stack=true"
 


### PR DESCRIPTION
For older plugins which use bazelisk, pin a version of bazel to avoid build failures when attempting to build with Bazel 8.x.