### PR TITLE
Update kotlin compiler to v2.1.0

### DIFF
--- a/plugins/connectrpc/kotlin/v0.7.2/buf.plugin.yaml
+++ b/plugins/connectrpc/kotlin/v0.7.2/buf.plugin.yaml
@@ -16,7 +16,8 @@ registry:
   maven:
     compiler:
       kotlin:
-        version: 1.8.22
+        api_version: "1.8"
+        version: "2.1.0"
     deps:
       - com.connectrpc:connect-kotlin:0.7.2
       - com.connectrpc:connect-kotlin-google-java-ext:0.7.2


### PR DESCRIPTION
Update the generated SDK for connect-kotlin to use the latest version of the kotlin compiler (for compatibility with the latest stdlib), but continue to build code that works on Kotlin API 1.8+.