### PR TITLE
Ignore bq-schema plugin version v3.0

### DIFF
--- a/plugins/googlecloudplatform/bq-schema/source.yaml
+++ b/plugins/googlecloudplatform/bq-schema/source.yaml
@@ -1,7 +1,6 @@
 source:
-  # Disabled until a new release is available.
-  # Ref: https://github.com/GoogleCloudPlatform/protoc-gen-bq-schema/pull/54#issuecomment-2619300559
-  disabled: true
+  ignore_versions:
+    - v3.0
   github:
     owner: GoogleCloudPlatform
     repository: protoc-gen-bq-schema

--- a/plugins/googlecloudplatform/bq-schema/source.yaml
+++ b/plugins/googlecloudplatform/bq-schema/source.yaml
@@ -1,4 +1,7 @@
 source:
+  # Disabled until a new release is available.
+  # Ref: https://github.com/GoogleCloudPlatform/protoc-gen-bq-schema/pull/54#issuecomment-2619300559
+  disabled: true
   github:
     owner: GoogleCloudPlatform
     repository: protoc-gen-bq-schema


### PR DESCRIPTION
The bq-schema plugin was released with version v3.0 which doesn't work with Go install. Ignore this version and wait for the next release.