### PR TITLE
Stop updating Bazel version in builds

### DIFF
--- a/.github/docker/Dockerfile.bazel
+++ b/.github/docker/Dockerfile.bazel
@@ -1,3 +1,0 @@
-FROM gcr.io/bazel-public/bazel:7.4.1
-
-CMD echo this is a dummy file used to automate dependency upgrades for plugins

--- a/internal/docker/baseimage_test.go
+++ b/internal/docker/baseimage_test.go
@@ -34,9 +34,6 @@ func TestBaseImages(t *testing.T) {
 	assert.NotEmpty(t, baseImages)
 	assert.NotEmpty(t, baseImages.ImageNameAndVersion("debian"))
 	assert.Empty(t, baseImages.ImageNameAndVersion("untracked"))
-	// Test just returning version
-	assert.NotEmpty(t, baseImages.ImageVersion("gcr.io/bazel-public/bazel"))
-	assert.NotContains(t, baseImages.ImageVersion("gcr.io/bazel-public/bazel"), "bazel:")
 	// Test distroless image upgrades
 	javaImage := baseImages.ImageNameAndVersion("gcr.io/distroless/java11-debian11")
 	assert.NotEmpty(t, javaImage)


### PR DESCRIPTION
We now use Bazel with bazelisk and pin exact versions (either the version specified in .bazelversion or in an env var). Remove Docker image for bazel and code to auto update Bazel in the fetcher.