### PR TITLE
Ignore v0.2.0 of connectrpc-dart

### DIFF
--- a/plugins/connectrpc/dart/source.yaml
+++ b/plugins/connectrpc/dart/source.yaml
@@ -1,4 +1,7 @@
 source:
+  ignore_versions:
+    # https://github.com/connectrpc/connect-dart/pull/6
+    - v0.2.0
   github:
     owner: connectrpc
     repository: connect-dart


### PR DESCRIPTION
Update config to ignore this version of the plugin - we'll pick up v0.2.1 when it is published.

Fixes #1687.