### PR TITLE
Add protocolbuffers/dart v22.2.0

### DIFF
--- a/plugins/protocolbuffers/dart/v22.2.0/.dockerignore
+++ b/plugins/protocolbuffers/dart/v22.2.0/.dockerignore
@@ -1,0 +1,2 @@
+*
+!Dockerfile

--- a/plugins/protocolbuffers/dart/v22.2.0/Dockerfile
+++ b/plugins/protocolbuffers/dart/v22.2.0/Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1.15
+FROM dart:3.7.3-sdk AS build
+
+WORKDIR /build
+RUN git clone --depth 1 --branch protoc_plugin-v22.2.0 https://github.com/google/protobuf.dart.git \
+ && cd protobuf.dart/protoc_plugin \
+ && dart pub get \
+ && dart compile exe bin/protoc_plugin.dart -o /build/protoc-gen-dart
+
+FROM scratch
+COPY --from=build --link /etc/passwd /etc/passwd
+COPY --from=build --link /runtime/ /
+COPY --from=build --link /build/protoc-gen-dart .
+USER nobody
+ENTRYPOINT [ "/protoc-gen-dart" ]

--- a/plugins/protocolbuffers/dart/v22.2.0/buf.plugin.yaml
+++ b/plugins/protocolbuffers/dart/v22.2.0/buf.plugin.yaml
@@ -1,0 +1,9 @@
+version: v1
+name: buf.build/protocolbuffers/dart
+plugin_version: v22.2.0
+source_url: https://github.com/google/protobuf.dart
+description: Base types for Dart. Generates message and enum types.
+output_languages:
+  - dart
+spdx_license_id: BSD-3-Clause
+license_url: https://github.com/google/protobuf.dart/blob/protoc_plugin-v22.2.0/LICENSE

--- a/tests/testdata/buf.build/protocolbuffers/dart/v22.2.0/eliza/plugin.sum
+++ b/tests/testdata/buf.build/protocolbuffers/dart/v22.2.0/eliza/plugin.sum
@@ -1,0 +1,1 @@
+h1:Odfj4y1lY5fk9HeNb/1pfuxX33QPuv/+1tUKaOYim/g=

--- a/tests/testdata/buf.build/protocolbuffers/dart/v22.2.0/petapis/plugin.sum
+++ b/tests/testdata/buf.build/protocolbuffers/dart/v22.2.0/petapis/plugin.sum
@@ -1,0 +1,1 @@
+h1:fg7HEP4kn9DQS1/bYVuXvvfLLrHGBzfxvnrmZFUOkuU=


### PR DESCRIPTION
Update protocolbuffers/dart plugin to the latest, which required tweaking the build to compile from a git clone instead of the release tarball (changed to use workspace dependencies).

Fixes #1841.