### PR TITLE
Update source for grpc/swift-protobuf

### DIFF
--- a/plugins/grpc/swift-protobuf/source.yaml
+++ b/plugins/grpc/swift-protobuf/source.yaml
@@ -1,4 +1,6 @@
 source:
   github:
+    # https://github.com/grpc/grpc-swift-protobuf had the initial v2 plugin version,
+    # which then moved to https://github.com/grpc/grpc-swift-2.
     owner: grpc
-    repository: grpc-swift-protobuf
+    repository: grpc-swift-2


### PR DESCRIPTION
https://github.com/grpc/grpc-swift-protobuf had the initial v2 plugin version, which then moved to https://github.com/grpc/grpc-swift-2.