### PR TITLE
Revert "Update source for grpc/swift-protobuf"

### DIFF
--- a/plugins/grpc/swift-protobuf/source.yaml
+++ b/plugins/grpc/swift-protobuf/source.yaml
@@ -1,6 +1,4 @@
 source:
   github:
-    # https://github.com/grpc/grpc-swift-protobuf had the initial v2 plugin version,
-    # which then moved to https://github.com/grpc/grpc-swift-2.
     owner: grpc
-    repository: grpc-swift-2
+    repository: grpc-swift-protobuf


### PR DESCRIPTION
Reverts bufbuild/plugins#1961

The plugin is still located at grpc-swift-protobuf, however the libraries it use moved to a new location. There is no new version of this plugin yet.