### PR TITLE
Ignore grpc/web v2.0.2 for now

### DIFF
--- a/plugins/grpc/web/source.yaml
+++ b/plugins/grpc/web/source.yaml
@@ -1,3 +1,6 @@
 source:
+  ignore_versions:
+    # Published to NPM but no corresponding GitHub tag or release assets.
+    - v2.0.2
   npm_registry:
     name: grpc-web


### PR DESCRIPTION
We discovered a new release in NPM but it doesn't have a corresponding tag or release assets so we can't build it.

Fixes #2024.