### PR TITLE
Change Python version specifiers for protobuf to `>=`

### DIFF
--- a/plugins/protocolbuffers/pyi/v32.1/buf.plugin.yaml
+++ b/plugins/protocolbuffers/pyi/v32.1/buf.plugin.yaml
@@ -14,5 +14,6 @@ registry:
     requires_python: ">=3.9"
     deps:
       # https://pypi.org/project/protobuf/
-      - "protobuf~=6.32.1"
-      - "types-protobuf~=6.30"
+      - "protobuf>=6.32.1"
+      # https://pypi.org/project/types-protobuf/
+      - "types-protobuf>=6.32"

--- a/plugins/protocolbuffers/python/v32.1/buf.plugin.yaml
+++ b/plugins/protocolbuffers/python/v32.1/buf.plugin.yaml
@@ -16,4 +16,4 @@ registry:
     requires_python: ">=3.9"
     deps:
       # https://pypi.org/project/protobuf/
-      - "protobuf~=6.32.1"
+      - "protobuf>=6.32.1"


### PR DESCRIPTION
The previous specifiers were too restrictive of maximum values; we _know_ the minimum version that we want to allow, but we leave it up to users to determine their maximum. (Newer versions of the `protobuf` runtime should support previous versions of gencode, [at least up to the next major version][1], but possibly further in practice.)

In terms of `types-protobuf`, the versions simply match the version of the runtime, and so similarly should not have an upper bound.

[1]: https://protobuf.dev/support/cross-version-runtime-guarantee/#major