### PR TITLE
Add tonic-prost crate dependency to tonic 0.5.0

### DIFF
--- a/plugins/community/neoeinstein-tonic/v0.5.0/buf.plugin.yaml
+++ b/plugins/community/neoeinstein-tonic/v0.5.0/buf.plugin.yaml
@@ -19,6 +19,8 @@ registry:
         req: "0.14.1"
         # https://github.com/hyperium/tonic/blob/v0.14.1/tonic/Cargo.toml#L27
         default_features: true
+      - name: "tonic-prost"
+        req: "0.14.1"
   # https://github.com/neoeinstein/protoc-gen-prost/tree/main/protoc-gen-tonic#options
   opts:
     - no_include=true


### PR DESCRIPTION
This was changed upstream, perhaps unintentionally, but our crates now need to pull in tonic-prost explicitly or they will fail to compile.

Ref: https://github.com/hyperium/tonic/commit/969408eeb110115e1f1d370f590d132346ca5fcf#r171907626