### PR TITLE
Re-enable stephenh/ts-proto plugin upgrades

### DIFF
--- a/plugins/community/stephenh-ts-proto/source.yaml
+++ b/plugins/community/stephenh-ts-proto/source.yaml
@@ -1,7 +1,3 @@
 source:
-  # Temporarily disabled until someone requests a new version or until
-  # we add the feature to update versions on a less frequent basis, see:
-  # https://github.com/bufbuild/plugins/issues/1039
-  disabled: true
   npm_registry:
     name: ts-proto


### PR DESCRIPTION
Releases are seemingly less frequent now; seems fine to keep this upgraded.

Fixes #2185.

Ref: https://github.com/stephenh/ts-proto/releases