### PR TITLE
Enable grpc/swift fetcher back

### DIFF
--- a/plugins/grpc/swift/source.yaml
+++ b/plugins/grpc/swift/source.yaml
@@ -1,11 +1,4 @@
 source:
-  # grpc-swift has upgraded to v2.0.0, but the protoc plugin is now split out
-  # into a separate grpc-swift-protobuf project. Unfortunately, the two
-  # projects are no longer versioned together - grpc-swift-protobuf is at
-  # v1.0.0.
-  # Disabling updates to this plugin until we can determine the best way
-  # forward.
-  disabled: true
   github:
     owner: grpc
     repository: grpc-swift


### PR DESCRIPTION
In https://github.com/bufbuild/plugins/pull/1695, `grpc/swift` fetcher was disabled.

However, it seems that:

* the gRPC Swift version 2 now lives in a separate [github.com/grpc/grpc-swift-2](https://github.com/grpc/grpc-swift-2) repository
* which shouldn't cause any conflicts for [github.com/grpc/grpc-swift](https://github.com/grpc/grpc-swift), which is now at 1.27.1

We need this for [github.com/cirruslabs/tart](https://github.com/cirruslabs/tart/blob/main/Package.swift), where:

* we're currently limited to version 1.24.2 of gRPC Swift
* ...but [](https://github.com/open-telemetry/opentelemetry-swift/blob/main/Package.swift) uses version 1.27.1
* ...which causes compilation failure