### PR TITLE
Fix the release parameter used in docker save

### DIFF
--- a/internal/cmd/release/main.go
+++ b/internal/cmd/release/main.go
@@ -224,7 +224,7 @@ func (c *command) calculateNewReleasePlugins(ctx context.Context, currentRelease
 		// Found existing release - only rebuild if changed image digest or buf.plugin.yaml digest
 		if pluginRelease.ImageID != imageID || pluginRelease.PluginYAMLDigest != pluginYamlDigest {
 			downloadURL := c.pluginDownloadURL(plugin, releaseName)
-			zipDigest, err := createPluginZip(ctx, c.logger, tmpDir, plugin, registryImage, imageID)
+			zipDigest, err := createPluginZip(ctx, c.logger, tmpDir, plugin, registryImage)
 			if err != nil {
 				return err
 			}
@@ -438,7 +438,6 @@ func createPluginZip(
 	basedir string,
 	plugin *plugin.Plugin,
 	registryImage string,
-	imageID string,
 ) (string, error) {
 	if err := pullImage(ctx, logger, registryImage); err != nil {
 		return "", err


### PR DESCRIPTION
Update the release parameter used in the docker save command. This should fix the release job to work as it did before.