### PR TITLE
Swap back to smaller runner sizes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ defaults:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest-4-cores
     steps:
     - name: set PLUGINS from workflow inputs
       if: ${{ inputs.plugins }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,7 +26,7 @@ jobs:
     env:
       BUILDKIT_PROGRESS: plain
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest-4-cores
     steps:
     - name: set PLUGINS from workflow inputs
       if: ${{ inputs.plugins }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
   release:
     environment: production
     if: github.repository == 'bufbuild/plugins'
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository code
         uses: actions/checkout@v6

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -25,7 +25,7 @@ jobs:
   release:
     environment: production
     if: github.repository == 'bufbuild/plugins'
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository code
         uses: actions/checkout@v6


### PR DESCRIPTION
No need anymore for these since they don't seem to speed up individual builds a ton, but we needed them for the extra disk et-al when rebuilding all the java ones