### PR TITLE
Manually add grpc/java plugin

### DIFF
--- a/plugins/grpc/java/v1.80.0/.dockerignore
+++ b/plugins/grpc/java/v1.80.0/.dockerignore
@@ -1,0 +1,3 @@
+*
+!Dockerfile
+!pom.xml

--- a/plugins/grpc/java/v1.80.0/Dockerfile
+++ b/plugins/grpc/java/v1.80.0/Dockerfile
@@ -1,0 +1,29 @@
+# syntax=docker/dockerfile:1.22
+FROM debian:bookworm-20260316 AS build
+
+ARG TARGETARCH
+
+WORKDIR /build
+RUN apt-get update \
+ && apt-get install -y curl
+RUN arch=${TARGETARCH}; \
+    if [ "${arch}" = "arm64" ]; then\
+        arch="aarch_64"; \
+    elif [ "${arch}" = "amd64" ]; then\
+        arch="x86_64"; \
+    fi; \
+    echo "${arch}"; \
+    curl -fsSL -o protoc-gen-grpc-java https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/1.80.0/protoc-gen-grpc-java-1.80.0-linux-${arch}.exe
+
+FROM gcr.io/distroless/cc-debian12:latest@sha256:329e54034ce498f9c6b345044e8f530c6691f99e94a92446f68c0adf9baa8464 AS base
+
+FROM maven:3.9.11-eclipse-temurin-21 AS maven-deps
+COPY pom.xml /tmp/pom.xml
+RUN cd /tmp && mvn -f pom.xml dependency:go-offline
+
+FROM scratch
+COPY --link --from=base / /
+COPY --link --from=build --chmod=0755 --chown=root:root /build/protoc-gen-grpc-java .
+COPY --from=maven-deps /root/.m2/repository /maven-repository
+USER nobody
+ENTRYPOINT [ "/protoc-gen-grpc-java" ]

--- a/plugins/grpc/java/v1.80.0/buf.plugin.yaml
+++ b/plugins/grpc/java/v1.80.0/buf.plugin.yaml
@@ -1,0 +1,30 @@
+version: v1
+name: buf.build/grpc/java
+plugin_version: v1.80.0
+source_url: https://github.com/grpc/grpc-java
+integration_guide_url: https://grpc.io/docs/languages/java/quickstart
+description: Generates Java client and server stubs for the gRPC framework.
+deps:
+  - plugin: buf.build/protocolbuffers/java:v34.0
+output_languages:
+  - java
+spdx_license_id: Apache-2.0
+license_url: https://github.com/grpc/grpc-java/blob/v1.80.0/LICENSE
+registry:
+  maven:
+    deps:
+      - io.grpc:grpc-core:1.80.0
+      - io.grpc:grpc-protobuf:1.80.0
+      - io.grpc:grpc-stub:1.80.0
+      # Add direct dependency on newer protobuf as gRPC is still on 3.25.8
+      - com.google.protobuf:protobuf-java:4.34.0
+    additional_runtimes:
+      - name: lite
+        deps:
+          - io.grpc:grpc-core:1.80.0
+          - io.grpc:grpc-protobuf-lite:1.80.0
+          - io.grpc:grpc-stub:1.80.0
+          # Add direct dependency on newer protobuf as gRPC is still on 3.25.8
+          - com.google.protobuf:protobuf-javalite:4.34.0
+          - build.buf:protobuf-javalite:4.34.0
+        opts: [lite]

--- a/plugins/grpc/java/v1.80.0/pom.xml
+++ b/plugins/grpc/java/v1.80.0/pom.xml
@@ -1,0 +1,44 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>temp</groupId>
+  <artifactId>temp</artifactId>
+  <version>1.0</version>
+  <dependencies>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-core</artifactId>
+      <version>1.80.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-protobuf</artifactId>
+      <version>1.80.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-stub</artifactId>
+      <version>1.80.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>4.34.0</version>
+    </dependency>
+    <!-- lite -->
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-protobuf-lite</artifactId>
+      <version>1.80.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-javalite</artifactId>
+      <version>4.34.0</version>
+    </dependency>
+    <dependency>
+      <groupId>build.buf</groupId>
+      <artifactId>protobuf-javalite</artifactId>
+      <version>4.34.0</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/tests/testdata/buf.build/grpc/java/v1.80.0/eliza/plugin.sum
+++ b/tests/testdata/buf.build/grpc/java/v1.80.0/eliza/plugin.sum
@@ -1,0 +1,1 @@
+h1:abVqnZfKuwUcrLQyb+Lu2QqyVxyEnfIosZqrc8Lv/f0=

--- a/tests/testdata/buf.build/grpc/java/v1.80.0/petapis/plugin.sum
+++ b/tests/testdata/buf.build/grpc/java/v1.80.0/petapis/plugin.sum
@@ -1,0 +1,1 @@
+h1:LtrVq0lTE5qfsjeZj2BqKoPibzJpnzDsSY/jO/SrmoY=


### PR DESCRIPTION
The grpc/java pins updated versions of com.google.protobuf dependencies, however when updating the plugin dependency we're not doing a second pass to update the pinned dependencies to match. For now, manually ran the fetcher to add the new version of the plugin.

Fixes #2339.