### PR TITLE
Update base images to debian 13

### DIFF
--- a/.github/docker/Dockerfile.dart
+++ b/.github/docker/Dockerfile.dart
@@ -1,3 +1,3 @@
-FROM dart:3.11.2-sdk
+FROM dart:3.11.2-sdk@sha256:d2a7e07b3e541587415d1281d4865a809149d723cff5b9a5ed6e8a2126b2b2d9
 
 CMD echo this is a dummy file used to automate dependency upgrades for plugins

--- a/.github/docker/Dockerfile.debian
+++ b/.github/docker/Dockerfile.debian
@@ -1,3 +1,3 @@
-FROM debian:bookworm-20260316
+FROM debian:trixie-20260316@sha256:55a15a112b42be10bfc8092fcc40b6748dc236f7ef46a358d9392b339e9d60e8
 
 CMD echo this is a dummy file used to automate dependency upgrades for plugins

--- a/.github/docker/Dockerfile.distroless-base-debian
+++ b/.github/docker/Dockerfile.distroless-base-debian
@@ -1,3 +1,3 @@
-FROM gcr.io/distroless/base-debian12:latest@sha256:937c7eaaf6f3f2d38a1f8c4aeff326f0c56e4593ea152e9e8f74d976dde52f56
+FROM gcr.io/distroless/base-debian13:latest@sha256:b0510424f0c7c1d6fdae75ef5c1d349fa72d312e96f69728fad6beb04755b8b4
 
 CMD echo this is a dummy file used to automate dependency upgrades for plugins

--- a/.github/docker/Dockerfile.distroless-cc-debian
+++ b/.github/docker/Dockerfile.distroless-cc-debian
@@ -1,3 +1,3 @@
-FROM gcr.io/distroless/cc-debian12:latest@sha256:329e54034ce498f9c6b345044e8f530c6691f99e94a92446f68c0adf9baa8464
+FROM gcr.io/distroless/cc-debian13:latest@sha256:e1cc90d06703f5dc30ae869fbfce78fce688f21a97efecd226375233a882e62f
 
 CMD echo this is a dummy file used to automate dependency upgrades for plugins

--- a/.github/docker/Dockerfile.distroless-java-debian
+++ b/.github/docker/Dockerfile.distroless-java-debian
@@ -1,3 +1,3 @@
-FROM gcr.io/distroless/java21-debian12:latest@sha256:f34fd3e4e2d7a246d764d0614f5e6ffb3a735930723fac4cfc25a72798950262
+FROM gcr.io/distroless/java25-debian13:latest@sha256:1382fd71a969441dd90c33f5815963810ff79846d85120760195f23fc7e220f5
 
 CMD echo this is a dummy file used to automate dependency upgrades for plugins

--- a/.github/docker/Dockerfile.distroless-nodejs-debian
+++ b/.github/docker/Dockerfile.distroless-nodejs-debian
@@ -1,3 +1,3 @@
-FROM gcr.io/distroless/nodejs24-debian12:latest@sha256:61f4f4341db81820c24ce771b83d202eb6452076f58628cd536cc7d94a10978b
+FROM gcr.io/distroless/nodejs24-debian13:latest@sha256:658a87364c8fcd8e09a199cbd06bf125932c32fe229993b2eda8fdde89b9f31e
 
 CMD echo this is a dummy file used to automate dependency upgrades for plugins

--- a/.github/docker/Dockerfile.distroless-python-debian
+++ b/.github/docker/Dockerfile.distroless-python-debian
@@ -1,3 +1,3 @@
-FROM gcr.io/distroless/python3-debian12:latest@sha256:e19b29c8473bed88f8b6e31e49d1133d1bdb2bf9c0af7e82d0e7434f7c036a63
+FROM gcr.io/distroless/python3-debian13:latest@sha256:cb8e12bde699c3912ed13022ed9aba6a9e6f093cf6e3ad5ded0fca36ccaedf93
 
 CMD echo this is a dummy file used to automate dependency upgrades for plugins

--- a/.github/docker/Dockerfile.distroless-static-debian
+++ b/.github/docker/Dockerfile.distroless-static-debian
@@ -1,3 +1,3 @@
-FROM gcr.io/distroless/static-debian12:latest@sha256:20bc6c0bc4d625a22a8fde3e55f6515709b32055ef8fb9cfbddaa06d1760f838
+FROM gcr.io/distroless/static-debian13:latest@sha256:47b2d72ff90843eb8a768b5c2f89b40741843b639d065b9b937b07cd59b479c6
 
 CMD echo this is a dummy file used to automate dependency upgrades for plugins

--- a/.github/docker/Dockerfile.golang
+++ b/.github/docker/Dockerfile.golang
@@ -1,3 +1,3 @@
-FROM golang:1.26.1-bookworm
+FROM golang:1.26.1-trixie@sha256:96b28783b99bcd265fbfe0b36a3ac6462416ce6bf1feac85d4c4ff533cbaa473
 
 CMD echo this is a dummy file used to automate dependency upgrades for plugins

--- a/.github/docker/Dockerfile.node
+++ b/.github/docker/Dockerfile.node
@@ -1,3 +1,3 @@
-FROM node:24.14.0-bookworm
+FROM node:24.14.0-trixie@sha256:8bd2aa8811c33803aa1677674e5388a4524e8bf1d286200afefb9a4c9bd473ef
 
 CMD echo this is a dummy file used to automate dependency upgrades for plugins

--- a/.github/docker/Dockerfile.python
+++ b/.github/docker/Dockerfile.python
@@ -1,3 +1,3 @@
-FROM python:3.11.15-bookworm
+FROM python:3.13.12-trixie@sha256:7412d2f7233f3ff3570424a4d112f18cd81b48644a75164edcea0e9d762087ab
 
 CMD echo this is a dummy file used to automate dependency upgrades for plugins

--- a/.github/docker/Dockerfile.rust
+++ b/.github/docker/Dockerfile.rust
@@ -1,3 +1,3 @@
-FROM rust:1.94.0-alpine3.22
+FROM rust:1.94.0-alpine3.23@sha256:ff0adc35894eb79586ce752a1b5a9eadc88b938c56d8f2b4b537b6258ff3fa10
 
 CMD echo this is a dummy file used to automate dependency upgrades for plugins

--- a/.github/docker/Dockerfile.swift
+++ b/.github/docker/Dockerfile.swift
@@ -1,3 +1,3 @@
-FROM swift:6.2.4-bookworm
+FROM swift:6.2.4-bookworm@sha256:6ff0d2567e1a9ce6b2bb1212a8d7ade9dc90e6fb02bed349fc664b981c206858
 
 CMD echo this is a dummy file used to automate dependency upgrades for plugins


### PR DESCRIPTION
Update distroless and build base images (that support it) to debian 13. Ran tests on all combinations and the latest plugins that rely on these images continue to build/pass locally.

Most of the distroless debian 12 images are EOL this year. Dart and Swift don't provide debian 13 images yet and our Rust builds have been using alpine all along so not attempting to upgrade them at this time.