### PR TITLE
Add anthropics/buffa-packaging plugin v0.3.0

### DIFF
--- a/plugins/anthropics/buffa-packaging/source.yaml
+++ b/plugins/anthropics/buffa-packaging/source.yaml
@@ -1,0 +1,3 @@
+source:
+  crates:
+    crate_name: protoc-gen-buffa-packaging

--- a/plugins/anthropics/buffa-packaging/v0.3.0/.dockerignore
+++ b/plugins/anthropics/buffa-packaging/v0.3.0/.dockerignore
@@ -1,0 +1,2 @@
+*
+!Dockerfile

--- a/plugins/anthropics/buffa-packaging/v0.3.0/Dockerfile
+++ b/plugins/anthropics/buffa-packaging/v0.3.0/Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1.19
+FROM rust:1.91.1-alpine3.22 AS builder
+RUN apk add --no-cache musl-dev
+WORKDIR /app
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked --mount=type=cache,target=/root/target \
+    cargo install protoc-gen-buffa-packaging --version 0.3.0 --locked --root /app
+
+FROM gcr.io/distroless/static-debian12:latest@sha256:87bce11be0af225e4ca761c40babb06d6d559f5767fbf7dc3c47f0f1a466b92c AS base
+
+FROM scratch
+COPY --link --from=base / /
+COPY --link --from=builder /app/bin/protoc-gen-buffa-packaging /protoc-gen-buffa-packaging
+USER nobody
+ENTRYPOINT ["/protoc-gen-buffa-packaging"]

--- a/plugins/anthropics/buffa-packaging/v0.3.0/buf.plugin.yaml
+++ b/plugins/anthropics/buffa-packaging/v0.3.0/buf.plugin.yaml
@@ -1,0 +1,9 @@
+version: v1
+name: buf.build/anthropics/buffa-packaging
+plugin_version: v0.3.0
+source_url: https://github.com/anthropics/buffa
+description: Emits a mod.rs module tree that includes per-file output from protoc-gen-buffa (and plugins layered on it). Run with strategy=all so the plugin sees the full file set in one invocation.
+output_languages:
+  - rust
+spdx_license_id: Apache-2.0
+license_url: https://github.com/anthropics/buffa/blob/v0.3.0/LICENSE


### PR DESCRIPTION
Adds the `protoc-gen-buffa-packaging` plugin for assembling buffa-style per-file output into a single `mod.rs` module tree.

## What this plugin does

[`protoc-gen-buffa-packaging`](https://crates.io/crates/protoc-gen-buffa-packaging) reads the proto package structure (not message/service bodies) and writes a `mod.rs` that `include!`s each generated file at the right module nesting level. It works with any codegen plugin that emits per-file output named via the buffa naming convention (`foo/v1/bar.proto` -> `foo.v1.bar.rs`), which includes [`protoc-gen-buffa`](https://crates.io/crates/protoc-gen-buffa) itself and plugins layered on top of it (like [`protoc-gen-connect-rust`](https://crates.io/crates/connectrpc-codegen)).

## Why register this in BSR

The buffa plugin (#2333) emits per-file output without a mod.rs. For local `buf generate` users, the packaging plugin assembles the module tree so the generated code can be used as `pub mod proto;` from a single `#[path]`. BSR's lib.rs synthesis handles the SDK-crate case differently, but BSR users who pull the plugin into a buf.gen.yaml workflow still need this packaging step.

## Options

- `filter=services` — only include proto files that declare at least one `service`. Useful when packaging output from a service-stub generator that skips files without services.

The plugin requires `strategy: all` (client-side concern in buf.gen.yaml) so it sees the full file set in one invocation.

## No registry block

This plugin emits only `mod.rs` files containing `#[path]` and `pub mod` declarations - no Rust code with cargo deps. So no `registry:` block is needed (same pattern as `community/neoeinstein-prost-crate`).

## Dependencies

Logically pairs with #2333 (anthropics/buffa) and #2334 (anthropics/connect-rust). The packaging plugin works on output from those plugins but does not declare them as plugin deps - it operates on the descriptor set, not on the generated code.

## Process note

CONTRIBUTING.md asks for an issue first - happy to open one if you would prefer to discuss before reviewing. Filed as draft.