### PR TITLE
Separate download/install phases in a couple Dockerfiles

### DIFF
--- a/plugins/bufbuild/connect-swift-mocks/v0.7.0/Dockerfile
+++ b/plugins/bufbuild/connect-swift-mocks/v0.7.0/Dockerfile
@@ -4,6 +4,7 @@ FROM swift:5.8.1-focal AS build
 WORKDIR /app
 RUN git clone --depth 1 --branch 0.7.0 https://github.com/bufbuild/connect-swift
 WORKDIR /app/connect-swift
+RUN swift package resolve
 RUN swift build -c release --product protoc-gen-connect-swift-mocks --static-swift-stdlib -Xlinker -s
 
 FROM gcr.io/distroless/cc-debian11

--- a/plugins/bufbuild/connect-swift/v0.7.0/Dockerfile
+++ b/plugins/bufbuild/connect-swift/v0.7.0/Dockerfile
@@ -4,6 +4,7 @@ FROM swift:5.8.1-focal AS build
 WORKDIR /app
 RUN git clone --depth 1 --branch 0.7.0 https://github.com/bufbuild/connect-swift
 WORKDIR /app/connect-swift
+RUN swift package resolve
 RUN swift build -c release --product protoc-gen-connect-swift --static-swift-stdlib -Xlinker -s
 
 FROM gcr.io/distroless/cc-debian11

--- a/plugins/community/roadrunner-server-php-grpc/v5.3.0/Dockerfile
+++ b/plugins/community/roadrunner-server-php-grpc/v5.3.0/Dockerfile
@@ -7,6 +7,9 @@ ENV CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH
 RUN git clone --depth=1 --branch v5.3.0 https://github.com/roadrunner-server/grpc.git
 RUN --mount=type=cache,target=/go/pkg/mod \
     cd grpc/protoc_plugins/protoc-gen-php-grpc \
+ && go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    cd grpc/protoc_plugins/protoc-gen-php-grpc \
  && go install -ldflags="-s -w" -trimpath \
  && mv /go/bin/${GOOS}_${GOARCH}/protoc-gen-php-grpc /go/bin/protoc-gen-php-grpc || true
 

--- a/plugins/grpc/go/v1.6.1/Dockerfile
+++ b/plugins/grpc/go/v1.6.1/Dockerfile
@@ -11,6 +11,8 @@ COPY separate-package.patch /tmp/grpc-go
 RUN git apply separate-package.patch
 WORKDIR /tmp/grpc-go/cmd/protoc-gen-go-grpc
 RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
     go build -o protoc-gen-go-grpc -ldflags "-s -w" -trimpath
 
 FROM scratch

--- a/plugins/grpc/swift-protobuf/v2.2.1/Dockerfile
+++ b/plugins/grpc/swift-protobuf/v2.2.1/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /app
 RUN git clone --depth 1 --branch 2.2.1 https://github.com/grpc/grpc-swift-protobuf --recursive
 WORKDIR /app/grpc-swift-protobuf
 COPY --link Package.resolved .
+RUN swift package resolve --force-resolved-versions
 RUN swift build -c release --static-swift-stdlib --product protoc-gen-grpc-swift-2 -Xlinker -s --force-resolved-versions
 
 FROM gcr.io/distroless/cc-debian12:latest@sha256:329e54034ce498f9c6b345044e8f530c6691f99e94a92446f68c0adf9baa8464 AS base


### PR DESCRIPTION
We don't necessarily need to merge _this_ PR, but just wanted to see if we were missing any places here where we could split up these steps for better layering. Found a couple places. We can also just keep these updates in mind for the next fetcher updates.