### PR TITLE
Cache golangci-lint in PR workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -72,6 +72,11 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Cache golangci-lint
+      uses: actions/cache@v4
+      with:
+        path: .tmp/golangci-lint-*
+        key: golangci-lint-${{ runner.os }}-${{ hashFiles('Makefile') }}
     - name: Lint
       run: make lint
     - name: Test


### PR DESCRIPTION
Noticed this wasn't getting cached; we should be able to cache the binary.

Ref: https://github.com/bufbuild/plugins/actions/runs/24728448571/job/72335866399?pr=2413