### PR TITLE
Cache golangci-lint binary in addition to versioned symlink

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -72,7 +72,9 @@ jobs:
     - name: Cache golangci-lint
       uses: actions/cache@v5
       with:
-        path: .tmp/golangci-lint-*
+        path: |
+          .tmp/golangci-lint
+          .tmp/golangci-lint-*
         key: golangci-lint-${{ runner.os }}-${{ hashFiles('Makefile') }}
     - name: Lint
       run: make lint


### PR DESCRIPTION
Noticed this wasn't being fully cached. The Makefile installs the golangci-lint binary to .tmp/golangci-lint via GOBIN, then creates a versioned symlink at .tmp/golangci-lint-<version>. The previous cache path only matched the symlink glob, leaving the actual binary uncached and requiring a fresh install on every run.

Ref: https://github.com/bufbuild/plugins/actions/runs/24997932372/job/73199781628#step:13:13