### PR TITLE
Disable protoc-gen-validate plugins

### DIFF
--- a/plugins/bufbuild/validate-cpp/source.yaml
+++ b/plugins/bufbuild/validate-cpp/source.yaml
@@ -1,5 +1,5 @@
 source:
-  # Use protovalidate instead
+  # Use https://protovalidate.com instead
   disabled: true
   github:
     owner: bufbuild

--- a/plugins/bufbuild/validate-cpp/source.yaml
+++ b/plugins/bufbuild/validate-cpp/source.yaml
@@ -1,4 +1,6 @@
 source:
+  # Use protovalidate instead
+  disabled: true
   github:
     owner: bufbuild
     repository: protoc-gen-validate

--- a/plugins/bufbuild/validate-go/source.yaml
+++ b/plugins/bufbuild/validate-go/source.yaml
@@ -1,5 +1,5 @@
 source:
-  # Use protovalidate instead
+  # Use https://protovalidate.com instead
   disabled: true
   github:
     owner: bufbuild

--- a/plugins/bufbuild/validate-go/source.yaml
+++ b/plugins/bufbuild/validate-go/source.yaml
@@ -1,4 +1,6 @@
 source:
+  # Use protovalidate instead
+  disabled: true
   github:
     owner: bufbuild
     repository: protoc-gen-validate

--- a/plugins/bufbuild/validate-java/source.yaml
+++ b/plugins/bufbuild/validate-java/source.yaml
@@ -1,5 +1,5 @@
 source:
-  # Use protovalidate instead
+  # Use https://protovalidate.com instead
   disabled: true
   github:
     owner: bufbuild

--- a/plugins/bufbuild/validate-java/source.yaml
+++ b/plugins/bufbuild/validate-java/source.yaml
@@ -1,4 +1,6 @@
 source:
+  # Use protovalidate instead
+  disabled: true
   github:
     owner: bufbuild
     repository: protoc-gen-validate


### PR DESCRIPTION
The PGV repo is archived and there will no longer be any updates to it. Disable looking for new versions in the fetcher.