### PR TITLE
Fix buf.plugin.yaml for connect-rust v0.6.1

### DIFF
--- a/plugins/anthropics/connect-rust/v0.6.1/buf.plugin.yaml
+++ b/plugins/anthropics/connect-rust/v0.6.1/buf.plugin.yaml
@@ -4,7 +4,7 @@ plugin_version: v0.6.1
 source_url: https://github.com/anthropics/connect-rust
 description: Generates ConnectRPC service traits, typed clients, and monomorphic dispatchers for Rust. Compatible with the Connect, gRPC, and gRPC-Web protocols. Passes the full ConnectRPC conformance suite.
 deps:
-  - plugin: buf.build/anthropics/buffa:v0.6.1
+  - plugin: buf.build/anthropics/buffa:v0.6.0
 output_languages:
   - rust
 spdx_license_id: Apache-2.0
@@ -22,7 +22,7 @@ registry:
       # buffa::bytes::Bytes directly. Message types live in the buffa SDK
       # crate (via the plugin dep above); this dep is for the runtime API.
       - name: "buffa"
-        req: "0.6.1"
+        req: "0.6.0"
         default_features: true
       # Well-known types. Service stubs whose request/response types are
       # WKTs (e.g. google.longrunning.Operations) reference them as
@@ -30,7 +30,7 @@ registry:
       # extern_path mapping for `.google.protobuf`. Must be a direct dep
       # so the `::buffa_types` path resolves in the generated crate.
       - name: "buffa-types"
-        req: "0.6.1"
+        req: "0.6.0"
         default_features: true
         features:
           - json

--- a/plugins/anthropics/connect-rust/v0.6.1/buf.plugin.yaml
+++ b/plugins/anthropics/connect-rust/v0.6.1/buf.plugin.yaml
@@ -4,7 +4,7 @@ plugin_version: v0.6.1
 source_url: https://github.com/anthropics/connect-rust
 description: Generates ConnectRPC service traits, typed clients, and monomorphic dispatchers for Rust. Compatible with the Connect, gRPC, and gRPC-Web protocols. Passes the full ConnectRPC conformance suite.
 deps:
-  - plugin: buf.build/anthropics/buffa:v0.7.0
+  - plugin: buf.build/anthropics/buffa:v0.6.0
 output_languages:
   - rust
 spdx_license_id: Apache-2.0
@@ -22,7 +22,7 @@ registry:
       # buffa::bytes::Bytes directly. Message types live in the buffa SDK
       # crate (via the plugin dep above); this dep is for the runtime API.
       - name: "buffa"
-        req: "0.6.1"
+        req: "0.6.0"
         default_features: true
       # Well-known types. Service stubs whose request/response types are
       # WKTs (e.g. google.longrunning.Operations) reference them as
@@ -30,7 +30,7 @@ registry:
       # extern_path mapping for `.google.protobuf`. Must be a direct dep
       # so the `::buffa_types` path resolves in the generated crate.
       - name: "buffa-types"
-        req: "0.6.1"
+        req: "0.6.0"
         default_features: true
         features:
           - json

--- a/plugins/anthropics/connect-rust/v0.6.1/buf.plugin.yaml
+++ b/plugins/anthropics/connect-rust/v0.6.1/buf.plugin.yaml
@@ -4,7 +4,7 @@ plugin_version: v0.6.1
 source_url: https://github.com/anthropics/connect-rust
 description: Generates ConnectRPC service traits, typed clients, and monomorphic dispatchers for Rust. Compatible with the Connect, gRPC, and gRPC-Web protocols. Passes the full ConnectRPC conformance suite.
 deps:
-  - plugin: buf.build/anthropics/buffa:v0.6.0
+  - plugin: buf.build/anthropics/buffa:v0.6.1
 output_languages:
   - rust
 spdx_license_id: Apache-2.0
@@ -22,7 +22,7 @@ registry:
       # buffa::bytes::Bytes directly. Message types live in the buffa SDK
       # crate (via the plugin dep above); this dep is for the runtime API.
       - name: "buffa"
-        req: "0.6.0"
+        req: "0.6.1"
         default_features: true
       # Well-known types. Service stubs whose request/response types are
       # WKTs (e.g. google.longrunning.Operations) reference them as
@@ -30,7 +30,7 @@ registry:
       # extern_path mapping for `.google.protobuf`. Must be a direct dep
       # so the `::buffa_types` path resolves in the generated crate.
       - name: "buffa-types"
-        req: "0.6.0"
+        req: "0.6.1"
         default_features: true
         features:
           - json


### PR DESCRIPTION
It actually depends on 0.6.0 of buffa: https://github.com/anthropics/connect-rust/blob/v0.6.1/Cargo.toml#L38-L40