### PR TITLE
Bump dependabot PR limit to 10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,7 @@ updates:
   # plugin base images
   - package-ecosystem: "docker"
     directory: "/baseimages"
+    open-pull-requests-limit: 10
     schedule:
       interval: "daily"
     registries:


### PR DESCRIPTION
When debian base images are updated, it leads to a cascade of updates across our other dockerfiles. We're currently hitting the 5 PR limit in this case. Bump it to 10 so we can process all docker image updates.