### PR TITLE
Disable updates for connectrpc/python plugin

### DIFF
--- a/plugins/connectrpc/python/source.yaml
+++ b/plugins/connectrpc/python/source.yaml
@@ -1,3 +1,5 @@
 source:
+  # Use connectrpc/py instead
+  disabled: true
   pypi:
     name: protoc-gen-connectrpc


### PR DESCRIPTION
This disables updates for the connectrpc/python plugin to reflect the rename of the project from connect-python to connect-py and to align with `bufbuild/py`. For more context, as the plugin has been rewritten from Go to Python, the current Dockerfile won't work either (missing the required `ln -sf /usr/bin/python /app/bin/python`). So disabling ensures no CI failures etc when we release the new connect-py package likely by tomorrow, and after that's released I can send the PR to add connectrpc/py with a very similar structure to connectrc/python but with the Python setup included.