### PR TITLE
Reduce JVM plugin image sizes by using jlink

### DIFF
--- a/baseimages/Dockerfile.distroless-java-debian
+++ b/baseimages/Dockerfile.distroless-java-debian
@@ -1,3 +1,0 @@
-FROM gcr.io/distroless/java25-debian13:latest@sha256:583ba2e08558063002bd1b5874a81b33b7204a0ad46727d4b6cbeff5a25935ba
-
-CMD echo this is a dummy file used to automate dependency upgrades for plugins

--- a/baseimages/Dockerfile.temurin
+++ b/baseimages/Dockerfile.temurin
@@ -1,0 +1,3 @@
+FROM eclipse-temurin:25-jdk@sha256:dfc0093e3dbf43dae57827111c6e374f5b44fac19a9451584b2b336b81474d64
+
+CMD echo this is a dummy file used to automate dependency upgrades for plugins

--- a/internal/docker/baseimage_test.go
+++ b/internal/docker/baseimage_test.go
@@ -34,10 +34,9 @@ func TestBaseImages(t *testing.T) {
 	assert.NotEmpty(t, baseImages.ImageNameAndVersion("debian"))
 	assert.Empty(t, baseImages.ImageNameAndVersion("untracked"))
 	// Test distroless image upgrades
-	javaImage := baseImages.ImageNameAndVersion("gcr.io/distroless/java11-debian11")
-	assert.NotEmpty(t, javaImage)
-	assert.NotContains(t, javaImage, "java11")   // Should be replaced with a later java image
-	assert.NotContains(t, javaImage, "debian11") // Should be replaced with a later debian image
+	ccImage := baseImages.ImageNameAndVersion("gcr.io/distroless/cc-debian11")
+	assert.NotEmpty(t, ccImage)
+	assert.NotContains(t, ccImage, "debian11") // Should be replaced with a later debian image
 }
 
 func TestBaseImagesNoDuplicateVersions(t *testing.T) {

--- a/plugins/apple/servicetalk/v0.42.64/Dockerfile
+++ b/plugins/apple/servicetalk/v0.42.64/Dockerfile
@@ -6,7 +6,11 @@ RUN apt-get update \
  && apt-get install -y curl
 RUN curl -fsSL -o servicetalk-grpc-protoc.jar https://repo1.maven.org/maven2/io/servicetalk/servicetalk-grpc-protoc/0.42.64/servicetalk-grpc-protoc-0.42.64-all.jar
 
-FROM gcr.io/distroless/java25-debian13:latest@sha256:3e0a1496b365a18d2c01ccfe27c8bc93b1a6b8ca7460c02b8badb791bf296fce AS base
+FROM eclipse-temurin:25-jdk@sha256:dfc0093e3dbf43dae57827111c6e374f5b44fac19a9451584b2b336b81474d64 AS jre
+RUN jlink --add-modules java.base,java.compiler,java.instrument,java.logging,java.management,jdk.unsupported \
+      --strip-debug --no-man-pages --no-header-files --output /jre
+
+FROM gcr.io/distroless/cc-debian13:latest@sha256:a017e74bd2a12d98342dbecd33d121d2b160415ed777573dc1808969e989d94d AS base
 
 FROM maven:3.9.11-eclipse-temurin-21 AS maven-deps
 COPY pom.xml /tmp/pom.xml
@@ -14,7 +18,8 @@ RUN cd /tmp && mvn -f pom.xml dependency:go-offline
 
 FROM scratch
 COPY --from=base --link / /
+COPY --from=jre --link /jre /jre
 COPY --from=build --link --chmod=0755 --chown=root:root /app/servicetalk-grpc-protoc.jar .
 COPY --from=maven-deps /root/.m2/repository /maven-repository
 USER nobody
-ENTRYPOINT [ "/usr/bin/java", "-jar", "/servicetalk-grpc-protoc.jar"]
+ENTRYPOINT [ "/jre/bin/java", "-jar", "/servicetalk-grpc-protoc.jar"]

--- a/plugins/bufbuild/connect-kotlin/v0.1.10/Dockerfile
+++ b/plugins/bufbuild/connect-kotlin/v0.1.10/Dockerfile
@@ -9,8 +9,13 @@ FROM maven:3.9.11-eclipse-temurin-21 AS maven-deps
 COPY pom.xml /tmp/pom.xml
 RUN cd /tmp && mvn -f pom.xml dependency:go-offline
 
-FROM gcr.io/distroless/java17-debian11
+FROM eclipse-temurin:25-jdk@sha256:dfc0093e3dbf43dae57827111c6e374f5b44fac19a9451584b2b336b81474d64 AS jre
+RUN jlink --add-modules java.base,java.compiler,java.instrument,java.logging,java.management,jdk.unsupported \
+      --strip-debug --no-man-pages --no-header-files --output /jre
+
+FROM gcr.io/distroless/cc-debian13:latest@sha256:a017e74bd2a12d98342dbecd33d121d2b160415ed777573dc1808969e989d94d
 WORKDIR /app
+COPY --from=jre --link /jre /jre
 COPY --from=build /app/protoc-gen-connect-kotlin.jar /app
 COPY --from=maven-deps /root/.m2/repository /maven-repository
-CMD ["/app/protoc-gen-connect-kotlin.jar"]
+ENTRYPOINT ["/jre/bin/java", "-jar", "/app/protoc-gen-connect-kotlin.jar"]

--- a/plugins/community/salesforce-reactive-grpc/v1.2.4/Dockerfile
+++ b/plugins/community/salesforce-reactive-grpc/v1.2.4/Dockerfile
@@ -5,7 +5,11 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y curl
 RUN curl -fsSL -o reactor-grpc-protoc.jar https://repo1.maven.org/maven2/com/salesforce/servicelibs/reactor-grpc/1.2.4/reactor-grpc-1.2.4.jar
 
-FROM gcr.io/distroless/java21-debian12:latest@sha256:7c9a9a362eadadb308d29b9c7fec2b39e5d5aa21d58837176a2cca50bdd06609 AS base
+FROM eclipse-temurin:25-jdk@sha256:dfc0093e3dbf43dae57827111c6e374f5b44fac19a9451584b2b336b81474d64 AS jre
+RUN jlink --add-modules java.base,java.compiler,java.instrument,java.logging,java.management,jdk.unsupported \
+      --strip-debug --no-man-pages --no-header-files --output /jre
+
+FROM gcr.io/distroless/cc-debian13:latest@sha256:a017e74bd2a12d98342dbecd33d121d2b160415ed777573dc1808969e989d94d AS base
 
 FROM maven:3.9.11-eclipse-temurin-21 AS maven-deps
 COPY pom.xml /tmp/pom.xml
@@ -13,7 +17,8 @@ RUN cd /tmp && mvn -f pom.xml dependency:go-offline
 
 FROM scratch
 COPY --from=base --link / /
+COPY --from=jre --link /jre /jre
 COPY --from=build --link --chmod=0755 --chown=root:root /app/reactor-grpc-protoc.jar .
 COPY --from=maven-deps /root/.m2/repository /maven-repository
 USER nobody
-ENTRYPOINT [ "/usr/bin/java", "-jar", "/reactor-grpc-protoc.jar"]
+ENTRYPOINT [ "/jre/bin/java", "-jar", "/reactor-grpc-protoc.jar"]

--- a/plugins/community/scalapb-scala/v0.11.20/Dockerfile
+++ b/plugins/community/scalapb-scala/v0.11.20/Dockerfile
@@ -9,10 +9,15 @@ RUN apt-get update \
 #This script embeds the the .class files and is a self contained jvm protoc plugin. See https://scalapb.github.io/docs/scalapbc/#using-scalapb-as-a-proper-protoc-plugin for more details
 RUN curl -fsSL -o protoc-gen-scala.jar https://repo1.maven.org/maven2/com/thesamet/scalapb/protoc-gen-scala/0.11.20/protoc-gen-scala-0.11.20-unix.sh
 
-FROM gcr.io/distroless/java21-debian12:latest@sha256:914d2e4d0aef6afe6167a11de8d87a4bfcd9325f36d1b45c03c04e6f16ba94d8 AS base
+FROM eclipse-temurin:25-jdk@sha256:dfc0093e3dbf43dae57827111c6e374f5b44fac19a9451584b2b336b81474d64 AS jre
+RUN jlink --add-modules java.base,java.compiler,java.instrument,java.logging,java.management,jdk.unsupported \
+      --strip-debug --no-man-pages --no-header-files --output /jre
+
+FROM gcr.io/distroless/cc-debian13:latest@sha256:a017e74bd2a12d98342dbecd33d121d2b160415ed777573dc1808969e989d94d AS base
 
 FROM scratch
 COPY --link --from=base / /
+COPY --from=jre --link /jre /jre
 COPY --link --from=build /protoc-gen-scala.jar .
 USER nobody
-ENTRYPOINT ["/usr/bin/java", "-jar", "/protoc-gen-scala.jar"]
+ENTRYPOINT ["/jre/bin/java", "-jar", "/protoc-gen-scala.jar"]

--- a/plugins/community/scalapb-zio-grpc/v0.6.3/Dockerfile
+++ b/plugins/community/scalapb-zio-grpc/v0.6.3/Dockerfile
@@ -9,10 +9,15 @@ RUN apt-get update \
 #This script embeds the the .class files and is a self contained jvm protoc plugin. See https://scalapb.github.io/docs/scalapbc/#using-scalapb-as-a-proper-protoc-plugin for more details
 RUN curl -fsSL -o protoc-gen-zio.jar https://repo1.maven.org/maven2/com/thesamet/scalapb/zio-grpc/protoc-gen-zio/0.6.3/protoc-gen-zio-0.6.3-unix.sh
 
-FROM gcr.io/distroless/java17-debian12:latest@sha256:26054428ef0fa1b71d28018e35823060c9e89d4b2f120d8efe1964669f44fccc AS base
+FROM eclipse-temurin:25-jdk@sha256:dfc0093e3dbf43dae57827111c6e374f5b44fac19a9451584b2b336b81474d64 AS jre
+RUN jlink --add-modules java.base,java.compiler,java.instrument,java.logging,java.management,jdk.unsupported \
+      --strip-debug --no-man-pages --no-header-files --output /jre
+
+FROM gcr.io/distroless/cc-debian13:latest@sha256:a017e74bd2a12d98342dbecd33d121d2b160415ed777573dc1808969e989d94d AS base
 
 FROM scratch
 COPY --from=base --link / /
+COPY --from=jre --link /jre /jre
 COPY --from=build --link /protoc-gen-zio.jar .
 USER nobody
-ENTRYPOINT ["/usr/bin/java", "-jar", "/protoc-gen-zio.jar"]
+ENTRYPOINT ["/jre/bin/java", "-jar", "/protoc-gen-zio.jar"]

--- a/plugins/connectrpc/kotlin/v0.9.0/Dockerfile
+++ b/plugins/connectrpc/kotlin/v0.9.0/Dockerfile
@@ -6,7 +6,11 @@ RUN apt-get update \
 WORKDIR /app
 RUN curl -fsSL -o /app/protoc-gen-connect-kotlin.jar https://repo1.maven.org/maven2/com/connectrpc/protoc-gen-connect-kotlin/0.9.0/protoc-gen-connect-kotlin-0.9.0.jar
 
-FROM gcr.io/distroless/java25-debian13:latest@sha256:583ba2e08558063002bd1b5874a81b33b7204a0ad46727d4b6cbeff5a25935ba as base
+FROM eclipse-temurin:25-jdk@sha256:dfc0093e3dbf43dae57827111c6e374f5b44fac19a9451584b2b336b81474d64 AS jre
+RUN jlink --add-modules java.base,java.compiler,java.instrument,java.logging,java.management,jdk.unsupported \
+      --strip-debug --no-man-pages --no-header-files --output /jre
+
+FROM gcr.io/distroless/cc-debian13:latest@sha256:a017e74bd2a12d98342dbecd33d121d2b160415ed777573dc1808969e989d94d as base
 
 FROM maven:3.9.11-eclipse-temurin-21 AS maven-deps
 COPY pom.xml /tmp/pom.xml
@@ -14,7 +18,8 @@ RUN cd /tmp && mvn -f pom.xml dependency:go-offline
 
 FROM scratch
 COPY --from=base --link / /
+COPY --from=jre --link /jre /jre
 COPY --from=build --link --chmod=0755 --chown=root:root /app/protoc-gen-connect-kotlin.jar .
 COPY --from=maven-deps /root/.m2/repository /maven-repository
 USER nobody
-ENTRYPOINT [ "/usr/bin/java", "-jar", "/protoc-gen-connect-kotlin.jar"]
+ENTRYPOINT [ "/jre/bin/java", "-jar", "/protoc-gen-connect-kotlin.jar"]

--- a/plugins/grpc/kotlin/v1.5.0/Dockerfile
+++ b/plugins/grpc/kotlin/v1.5.0/Dockerfile
@@ -8,7 +8,11 @@ RUN apt-get update \
  && apt-get install -y curl
 RUN curl -fsSL -o protoc-gen-grpc-kotlin.jar https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-kotlin/1.5.0/protoc-gen-grpc-kotlin-1.5.0-jdk8.jar
 
-FROM gcr.io/distroless/java21-debian12:latest@sha256:418b2e2a9e452aa9299511427f2ae404dfc910ecfa78feb53b1c60c22c3b640c AS base
+FROM eclipse-temurin:25-jdk@sha256:dfc0093e3dbf43dae57827111c6e374f5b44fac19a9451584b2b336b81474d64 AS jre
+RUN jlink --add-modules java.base,java.compiler,java.instrument,java.logging,java.management,jdk.unsupported \
+      --strip-debug --no-man-pages --no-header-files --output /jre
+
+FROM gcr.io/distroless/cc-debian13:latest@sha256:a017e74bd2a12d98342dbecd33d121d2b160415ed777573dc1808969e989d94d AS base
 
 FROM maven:3.9.11-eclipse-temurin-21 AS maven-deps
 COPY pom.xml /tmp/pom.xml
@@ -16,7 +20,8 @@ RUN cd /tmp && mvn -f pom.xml dependency:go-offline
 
 FROM scratch
 COPY --link --from=base / /
+COPY --from=jre --link /jre /jre
 COPY --link --from=build --chmod=0644 --chown=root:root /build/protoc-gen-grpc-kotlin.jar .
 COPY --from=maven-deps /root/.m2/repository /maven-repository
 USER nobody
-ENTRYPOINT [ "/usr/bin/java", "-jar", "/protoc-gen-grpc-kotlin.jar" ]
+ENTRYPOINT [ "/jre/bin/java", "-jar", "/protoc-gen-grpc-kotlin.jar" ]


### PR DESCRIPTION
Use jlink to prepare a smaller JRE containing just what is needed to execute the plugin. After building the 7 plugins locally, the size is reduced across the board by 287mb (compressed) and 869mb (uncompressed).

| Runtime | Compressed | Uncompressed |
| --- | --: | --: |
| Full distroless JRE (`java25-debian13`) | 72.7 MB | 228.0 MB |
| jlink runtime (`cc-debian13` + minimal modules) | 30.0 MB | 88.6 MB |
| **Per plugin savings** | **-42.7 MB (-59%)** | **-139.4 MB (-61%)** |
