### PR TITLE
Prepare for creation of connectrpc/rust

### DIFF
--- a/plugins/anthropics/connect-rust/source.yaml
+++ b/plugins/anthropics/connect-rust/source.yaml
@@ -1,3 +1,5 @@
 source:
+  # Moved to connectrpc/rust
+  disabled: true
   crates:
     crate_name: connectrpc-codegen


### PR DESCRIPTION
Disable updates in the old plugin name now that the upstream project exists in the connectrpc org.