### PR TITLE
Update golang base image

### DIFF
--- a/baseimages/Dockerfile.golang
+++ b/baseimages/Dockerfile.golang
@@ -1,3 +1,3 @@
-FROM golang:1.26.4-trixie@sha256:68b7145ec43d1820b9a56704554b53d1520aa2a15cb5233e374188a31b2a1bce
+FROM golang:1.26.5-trixie@sha256:8d5bf3ef8fd204fea2ea0dea4b46d4ecdabceb88b9b4cb86d2b323425add49c7
 
 CMD echo this is a dummy file used to automate dependency upgrades for plugins


### PR DESCRIPTION
Dependabot attempted to update to 1.27rc2 instead of the latest patch release.