### PR TITLE
Remove patch from go.mod go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bufbuild/plugins
 
-go 1.26.0
+go 1.26
 
 require (
 	aead.dev/minisign v0.3.0


### PR DESCRIPTION
The actions/setup-go GHA will not use the latest security/bugfix version of Go if the patch version is zero (even with `use-latest-version`). To work around this for now, remove the patch version from go.mod which should allow it to run with later versions.