### PR TITLE
Move to gcloud storage command

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           go run ./cmd/download-plugins -since "${SINCE}" downloads
       - name: Upload To Release Bucket
-        run: gsutil -m rsync -r downloads gs://buf-plugins
+        run: gcloud storage rsync --recursive downloads gs://buf-plugins
       - name: Generate Github Token
         id: generate_issues_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0


### PR DESCRIPTION
The gsutil command is deprecated and it is recommended to move to the 'gcloud storage' command instead.