### PR TITLE
Remove TestMavenDependencies test

### DIFF
--- a/tests/plugins_test.go
+++ b/tests/plugins_test.go
@@ -306,43 +306,6 @@ func TestGrpcGatewayDeprecationMessage(t *testing.T) {
 	}
 }
 
-func TestMavenDependencies(t *testing.T) {
-	t.Parallel()
-	ctx := t.Context()
-	client := &http.Client{}
-	plugins := loadFilteredPlugins(t)
-	for _, p := range plugins {
-		if p.Registry.Maven == nil || len(p.Registry.Maven.Deps) == 0 {
-			continue
-		}
-		t.Run(fmt.Sprintf("%s/%s@%s", p.Identity.Owner(), p.Identity.Plugin(), p.PluginVersion), func(t *testing.T) {
-			t.Parallel()
-			var alldeps []string
-			alldeps = append(alldeps, p.Registry.Maven.Deps...)
-			for _, runtime := range p.Registry.Maven.AdditionalRuntimes {
-				alldeps = append(alldeps, runtime.Deps...)
-			}
-			for _, dep := range alldeps {
-				fields := strings.Split(dep, ":")
-				require.Len(t, fields, 3)
-				groupID, artifactID, version := fields[0], fields[1], fields[2]
-				url := fmt.Sprintf(
-					"https://repo.maven.apache.org/maven2/%[1]s/%[2]s/%[3]s/%[2]s-%[3]s.pom",
-					strings.ReplaceAll(groupID, ".", "/"),
-					artifactID,
-					version,
-				)
-				req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
-				require.NoError(t, err)
-				resp, err := client.Do(req)
-				require.NoError(t, err)
-				require.NoError(t, resp.Body.Close())
-				assert.Equalf(t, http.StatusOK, resp.StatusCode, "failed to find maven dependency %s", dep)
-			}
-		})
-	}
-}
-
 func TestMavenPOMInSync(t *testing.T) {
 	t.Parallel()
 	plugins := loadFilteredPlugins(t)


### PR DESCRIPTION
The TestMavenDependencies test is failing more often with 429 errors due to rate limiting on Maven Central. Instead of working around the issue by reducing parallelism or using a mirror, remove the test. All Java/Kotlin plugins now include their dependencies in the built docker image to enable air gapped builds so the test is no longer necessary.