### PR TITLE
Ignore grpc-web v2.1.0 until release assets are published

### DIFF
--- a/plugins/grpc/web/source.yaml
+++ b/plugins/grpc/web/source.yaml
@@ -1,3 +1,7 @@
 source:
   npm_registry:
     name: grpc-web
+  ignore_versions:
+    # 2.1.0 was published to npm and tagged, but no GitHub release was cut, so
+    # the source tarball the Dockerfile downloads does not exist.
+    - v2.1.0


### PR DESCRIPTION
npm has 2.1.0 and the tag exists, but no GitHub release was cut for it.

Fixes #2639.