### PR TITLE
Disable nanopb v0.4.92

### DIFF
--- a/plugins/community/nanopb/source.yaml
+++ b/plugins/community/nanopb/source.yaml
@@ -2,3 +2,6 @@ source:
   github:
     owner: nanopb
     repository: nanopb
+  ignore_versions:
+    # Git tag exists but pypi release isn't out yet.
+    - v0.4.92


### PR DESCRIPTION
The nanopb GitHub repo has a tag for v0.4.92 but there isn't a release yet published to pypi.

Fixes #2680.