### PR TITLE
Extend docker rm timeout from default 20s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ else
 	docker buildx inspect "$(DOCKER_BUILDER)" 2> /dev/null || docker buildx create --use --bootstrap --name="$(DOCKER_BUILDER)" > /dev/null
 	$(GO) run ./internal/cmd/dockerbuild -cache-dir "$(DOCKER_CACHE_DIR)" -org "$(DOCKER_ORG)" -- $(DOCKER_BUILD_EXTRA_ARGS) || \
 		(docker buildx rm "$(DOCKER_BUILDER)"; exit 1)
-	docker buildx rm "$(DOCKER_BUILDER)" > /dev/null
+	docker buildx rm --timeout 5m "$(DOCKER_BUILDER)" > /dev/null
 endif
 
 .PHONY: lint


### PR DESCRIPTION
Update to use a 5m timeout instead of the default 20s. Under load we're seeing context cancellation and failures removing the builder.